### PR TITLE
Bugfix/DASH-691: control variables are visible to users outside of experiment

### DIFF
--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -111,7 +111,7 @@ describe("Context", () => {
 				variants: [
 					{
 						name: "A",
-						config: null,
+						config: '{ "card.width": "100%" }',
 					},
 					{
 						name: "B",

--- a/src/context.js
+++ b/src/context.js
@@ -473,7 +473,7 @@ export default class Context {
 					this._queueExposure(experimentName, assignment);
 				}
 
-				if (key in assignment.variables) {
+				if (key in assignment.variables && assignment.eligible) {
 					return assignment.variables[key];
 				}
 			}
@@ -487,7 +487,7 @@ export default class Context {
 			const experimentName = this._indexVariables[key][i].data.name;
 			const assignment = this._assign(experimentName);
 			if (assignment.variables !== undefined) {
-				if (key in assignment.variables) {
+				if (key in assignment.variables && assignment.eligible) {
 					return assignment.variables[key];
 				}
 			}


### PR DESCRIPTION
This PR adds a check for assignment eligibility before returning a variable value. This prevents ineligible participants from receiving variables, even though they are technically in the control group.