### PR TITLE
changed module index file type

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	],
 	"license": "Apache-2.0",
 	"main": "lib/index.js",
-	"module": "es/index.js",
+	"module": "es/index.mjs",
 	"browser": "dist/absmartly.min.js",
 	"engines": {
 		"npm": ">=3",


### PR DESCRIPTION
Small change to reference the correct file type for es modules. Discovered as we just switched to using Vite

![image](https://user-images.githubusercontent.com/20829240/231603481-e4f40081-c179-4ddb-abca-94b51a28dae2.png)
