### PR TITLE
Fix module bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -75,7 +75,7 @@ module.exports = function (api) {
 			});
 			break;
 
-		case "mjs":
+		case "es":
 			Object.assign(runtime[1], {
 				useESModules: true,
 			});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	],
 	"license": "Apache-2.0",
 	"main": "lib/index.js",
-	"module": "es/index.mjs",
+	"module": "es/index.js",
 	"browser": "dist/absmartly.min.js",
 	"engines": {
 		"npm": ">=3",
@@ -26,8 +26,8 @@
 	"scripts": {
 		"build-browser": "TARGET=browser webpack --progress --config webpack.config.js && TARGET=browser NODE_ENV=production webpack --progress --config webpack.config.js",
 		"build-cjs": "TARGET=cjs babel src --delete-dir-on-start --ignore 'src/__tests__' --ignore 'src/browser.js' -d lib",
-		"build-mjs": "TARGET=mjs babel src --delete-dir-on-start --ignore 'src/__tests__' --ignore 'src/browser.js' --out-file-extension=.mjs -d es",
-		"build": "npm run -s format && npm run -s lint && npm run -s test && npm run -s build-mjs && npm run -s build-cjs && npm run -s build-browser",
+		"build-es": "TARGET=es babel src --delete-dir-on-start --ignore 'src/__tests__' --ignore 'src/browser.js' -d es",
+		"build": "npm run -s format && npm run -s lint && npm run -s test && npm run -s build-es && npm run -s build-cjs && npm run -s build-browser",
 		"lint": "eslint -f stylish 'src/**/*.{js,mjs,jsx}'",
 		"format": "prettier --write '**/*.{js,mjs,jsx,json}'",
 		"prepack": "npm run -s build",


### PR DESCRIPTION
I have been messing around with getting the javascript SDK working in Storybook. I ran into some build issues and noticed that the emitted `.mjs` files under the `/es` directory don't adhere to the ECMAscript specification. 

Here's what I'm seeing when trying to use this package in Storybook:

![image](https://github.com/absmartly/javascript-sdk/assets/1687560/b4395b6a-2645-487b-a599-49125f44d3e5)

Files that are marked `.mjs` need to have the file extension specified in the imports, for example `import { md5 } from "./md5.mjs";` is correct while `import { md5 } from "./md5";` is not.

I could fix this with my Storybook configuration, but I felt that fixing it here would be more correct.

The fix is fairly straightforward as all we need to do is remove the `--out-file-extension=.mjs` argument and update the `package.json` to point to the new `./es/index.js` file. This works because `.js` files that use the ECMAScript syntax are backwards compatible with the earlier standards which don't require file extensions.

I have also updated a few instances of `mjs` to `es` to make this more clear.

I have tested this locally by using `yarn link` from our Storybook instance and it works for me.

Let me know if there's anything else I need to do for this PR