### PR TITLE
Bugfix/core js is required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.11.1",
+	"version": "1.11.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@absmartly/javascript-sdk",
-			"version": "1.11.1",
+			"version": "1.11.5",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"core-js": "^3.20.0",
 				"node-fetch": "^2.6.7",
 				"rfdc": "^1.2.0"
 			},
@@ -31,7 +32,6 @@
 				"@babel/register": "^7.17.0",
 				"babel-jest": "^26.6.3",
 				"babel-loader": "^8.2.3",
-				"core-js": "^3.20.0",
 				"eslint": "^7.32.0",
 				"eslint-config-prettier": "^7.1.0",
 				"jest": "^26.6.3",
@@ -4014,7 +4014,6 @@
 			"version": "3.26.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
 			"integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
-			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -14165,8 +14164,7 @@
 		"core-js": {
 			"version": "3.26.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
-			"integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
-			"dev": true
+			"integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
 		},
 		"core-js-compat": {
 			"version": "3.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.11.5",
+	"version": "1.11.7",
 	"description": "A/B Smartly Javascript SDK",
 	"homepage": "https://github.com/absmartly/javascript-sdk#README.md",
 	"bugs": "https://github.com/absmartly/javascript-sdk/issues",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
 	},
 	"dependencies": {
 		"node-fetch": "^2.6.7",
-		"rfdc": "^1.2.0"
+		"rfdc": "^1.2.0",
+		"core-js": "^3.20.0"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.17.3",
@@ -56,7 +57,6 @@
 		"@babel/register": "^7.17.0",
 		"babel-jest": "^26.6.3",
 		"babel-loader": "^8.2.3",
-		"core-js": "^3.20.0",
 		"eslint": "^7.32.0",
 		"eslint-config-prettier": "^7.1.0",
 		"jest": "^26.6.3",


### PR DESCRIPTION
This PR moves core-js from being a dev dependency to being a regular dependency. This stops the `Module not found` error that was occuring.