### PR TITLE
Added `types/` to files list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.12.0",
+	"version": "1.12.1",
 	"description": "A/B Smartly Javascript SDK",
 	"homepage": "https://github.com/absmartly/javascript-sdk#README.md",
 	"bugs": "https://github.com/absmartly/javascript-sdk/issues",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"package.json",
 		"dist/",
 		"es/",
-		"lib/"
+		"lib/",
+		"types/"
 	]
 }


### PR DESCRIPTION
This PR adds the `types` directory to the package.json files list. This should include the package types when downloading with npm.