### PR TITLE
DASH-1249: ReactNative support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.12.1",
+	"version": "1.12.2",
 	"description": "A/B Smartly Javascript SDK",
 	"homepage": "https://github.com/absmartly/javascript-sdk#README.md",
 	"bugs": "https://github.com/absmartly/javascript-sdk/issues",

--- a/src/abort.ts
+++ b/src/abort.ts
@@ -1,9 +1,9 @@
-import { isBrowser, isWorker } from "./utils";
+import { isLongLivedApp, isWorker } from "./utils";
 import AbortControllerShim from "./abort-controller-shim";
 
 // eslint-disable-next-line no-shadow
 export const AbortController =
-	isBrowser() && window.AbortController
+	isLongLivedApp() && window.AbortController
 		? window.AbortController
 		: isWorker() && self.AbortController
 		? self.AbortController

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,7 +1,7 @@
-import { isBrowser, isWorker } from "./utils";
+import { isLongLivedApp, isWorker } from "./utils";
 import fetchShim from "./fetch-shim";
 
-const exported = isBrowser()
+const exported = isLongLivedApp()
 	? window.fetch
 		? window.fetch.bind(window)
 		: fetchShim

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2,7 +2,7 @@ import Client, { ClientOptions, ClientRequestOptions } from "./client";
 import Context, { ContextData, ContextOptions, ContextParams, Exposure, Goal } from "./context";
 import { ContextPublisher, PublishParams } from "./publisher";
 import { ContextDataProvider } from "./provider";
-import { isBrowser } from "./utils";
+import { isLongLivedApp } from "./utils";
 
 export type EventLoggerData = Error | Exposure | Goal | ContextData | PublishParams;
 
@@ -110,7 +110,7 @@ export default class SDK {
 	private static _contextOptions(options?: Partial<ContextOptions>): ContextOptions {
 		return Object.assign(
 			{
-				publishDelay: isBrowser() ? 100 : -1,
+				publishDelay: isLongLivedApp() ? 100 : -1,
 				refreshPeriod: 0,
 			},
 			options || {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,19 @@ export const getApplicationName = (app: string | { name: string; version: number
 export const getApplicationVersion = (app: string | { name: string; version: number }): number =>
 	typeof app !== "string" ? app.version : 0;
 
-export function isBrowser() {
+function isBrowser() {
 	return typeof window !== "undefined" && typeof window.document !== "undefined";
+}
+
+function isReactNative() {
+	return typeof navigator !== "undefined" && navigator.product === "ReactNative";
+}
+
+export function isLongLivedApp() {
+	if (typeof navigator !== "undefined") {
+		console.dir(navigator.product);
+	}
+	return isBrowser() || isReactNative();
 }
 
 export function isWorker() {


### PR DESCRIPTION
This PR adds ReactNative support to the Javascript SDK.

Calling `context.track()` was failing in ReactNative as the `isBrowser()` function looks for `window.document`.

React Native does not have a `window.document`, so now we check for `isLongLivedApp()` instead.
