### PR TITLE
Remove console log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.12.2",
+	"version": "1.12.3",
 	"description": "A/B Smartly Javascript SDK",
 	"homepage": "https://github.com/absmartly/javascript-sdk#README.md",
 	"bugs": "https://github.com/absmartly/javascript-sdk/issues",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,9 +15,6 @@ function isReactNative() {
 }
 
 export function isLongLivedApp() {
-	if (typeof navigator !== "undefined") {
-		console.dir(navigator.product);
-	}
 	return isBrowser() || isReactNative();
 }
 


### PR DESCRIPTION
This PR removes a rogue `console.dir()` that appeared in the ReactNative support PR.
