### PR TITLE
Fix plain object detection in edge-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.13.1",
+	"version": "1.13.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@absmartly/javascript-sdk",
-			"version": "1.13.1",
+			"version": "1.13.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"core-js": "^3.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.13.0",
+	"version": "1.13.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@absmartly/javascript-sdk",
-			"version": "1.13.0",
+			"version": "1.13.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"core-js": "^3.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.13.1",
+	"version": "1.13.2",
 	"description": "A/B Smartly Javascript SDK",
 	"homepage": "https://github.com/absmartly/javascript-sdk#README.md",
 	"bugs": "https://github.com/absmartly/javascript-sdk/issues",

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -10,9 +10,12 @@ import {
 	stringToUint8Array,
 } from "../utils";
 
+class SomeClass {}
+
 describe("isObject()", () => {
 	it("should return true with objects", (done) => {
 		expect(isObject({})).toBe(true);
+		expect(isObject(new Object())).toBe(true);
 
 		done();
 	});
@@ -25,6 +28,8 @@ describe("isObject()", () => {
 		expect(isObject(false)).toBe(false);
 		expect(isObject("str")).toBe(false);
 		expect(isObject(new Uint8Array(1))).toBe(false);
+		expect(isObject(new Map())).toBe(false);
+		expect(isObject(new SomeClass())).toBe(false);
 
 		done();
 	});
@@ -45,6 +50,8 @@ describe("isNumeric()", () => {
 		expect(isNumeric(false)).toBe(false);
 		expect(isNumeric([])).toBe(false);
 		expect(isNumeric({})).toBe(false);
+		expect(isNumeric(new Object())).toBe(false);
+		expect(isNumeric(new Map())).toBe(false);
 
 		done();
 	});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,12 @@ export function isNumeric(value: unknown): value is number {
 }
 
 export function isObject(value: unknown): value is Record<string, unknown> {
-	return value instanceof Object && value.constructor === Object;
+	if (!(value instanceof Object)) {
+		return false;
+	}
+
+	const proto = Object.getPrototypeOf(value);
+	return proto == null || proto === Object.prototype;
 }
 
 export function isPromise(value: unknown): value is Promise<unknown> {


### PR DESCRIPTION
This PR fixes plain object detection when running on edge-runtime.
When running on edge-runtime `{}.constructor == Object` is `false` while on node and browsers it's true.
Checking for the prototypes seems to be more robust.