### PR TITLE
feat: add custom assignment rules evaluation

### DIFF
--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2650,6 +2650,89 @@ describe("Context", () => {
 			const context = new Context(sdk, contextOptions, contextParams, badJsonResponse);
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
+
+		it("should not invalidate cache when out-of-range rule variant changes to a different out-of-range value", () => {
+			const oobRulesResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+							}),
+							assignmentRules: JSON.stringify({
+								rules: [
+									{
+										name: "OOB Rule US",
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+										environments: [],
+										variant: 99,
+									},
+									{
+										name: "OOB Rule GB",
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
+										environments: [],
+										variant: 100,
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, oobRulesResponse);
+
+			context.attribute("country", "US");
+			const first = context.treatment("exp_test_abc");
+
+			context.attribute("country", "GB");
+			const second = context.treatment("exp_test_abc");
+
+			expect(first).toEqual(second);
+		});
+
+		it("should normalise out-of-range ruleVariant to null in cached assignment", (done) => {
+			const oobResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+							}),
+							assignmentRules: JSON.stringify({
+								rules: [
+									{
+										name: "OOB Rule",
+										type: "assign",
+										conditions: null,
+										environments: [],
+										variant: 99,
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, oobResponse);
+			context.treatment("exp_test_abc");
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
+				expect(exposure.ruleOverride).toBe(false);
+				done();
+			});
+		});
 	});
 
 	describe("variableValue()", () => {

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2055,85 +2055,68 @@ describe("Context", () => {
 	});
 
 	describe("rules evaluation", () => {
-		const rulesContextResponse = {
+		const buildRulesResponse = (overrides = {}, responseOverrides = {}) => ({
 			...getContextResponse,
+			...responseOverrides,
 			experiments: getContextResponse.experiments.map((x) => {
 				if (x.name === "exp_test_abc") {
-					return {
-						...x,
-						audience: JSON.stringify({
-							filter: [{ value: true }],
-						}),
-						assignmentRules: JSON.stringify({
-							rules: [
-								{
-									name: "US Internal Users",
-									type: "assign",
-									conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-									environments: [],
-									variant: 1,
-								},
-							],
-						}),
-					};
+					return { ...x, ...overrides };
 				}
 				return x;
 			}),
-		};
+		});
 
-		const envScopedRulesContextResponse = {
-			...getContextResponse,
-			environment_id: 10,
-			experiments: getContextResponse.experiments.map((x) => {
-				if (x.name === "exp_test_abc") {
-					return {
-						...x,
-						audience: JSON.stringify({
-							filter: [{ value: true }],
-						}),
-						assignmentRules: JSON.stringify({
-							rules: [
-								{
-									name: "Production Only",
-									type: "assign",
-									conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-									environments: [10],
-									variant: 1,
-								},
-							],
-						}),
-					};
-				}
-				return x;
+		const rulesContextResponse = buildRulesResponse({
+			audience: JSON.stringify({
+				filter: [{ value: true }],
 			}),
-		};
+			assignmentRules: JSON.stringify({
+				rules: [
+					{
+						name: "US Internal Users",
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+						environments: [],
+						variant: 1,
+					},
+				],
+			}),
+		});
 
-		const rulesStrictContextResponse = {
-			...getContextResponse,
-			experiments: getContextResponse.experiments.map((x) => {
-				if (x.name === "exp_test_abc") {
-					return {
-						...x,
-						audienceStrict: true,
-						audience: JSON.stringify({
-							filter: [{ gte: [{ var: "age" }, { value: 20 }] }],
-						}),
-						assignmentRules: JSON.stringify({
-							rules: [
-								{
-									name: "US Users",
-									type: "assign",
-									conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-									environments: [],
-									variant: 1,
-								},
-							],
-						}),
-					};
-				}
-				return x;
+		const envScopedRulesContextResponse = buildRulesResponse({
+			audience: JSON.stringify({
+				filter: [{ value: true }],
 			}),
-		};
+			assignmentRules: JSON.stringify({
+				rules: [
+					{
+						name: "Production Only",
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+						environments: [10],
+						variant: 1,
+					},
+				],
+			}),
+		}, { environment_id: 10 });
+
+		const rulesStrictContextResponse = buildRulesResponse({
+			audienceStrict: true,
+			audience: JSON.stringify({
+				filter: [{ gte: [{ var: "age" }, { value: 20 }] }],
+			}),
+			assignmentRules: JSON.stringify({
+				rules: [
+					{
+						name: "US Users",
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+						environments: [],
+						variant: 1,
+					},
+				],
+			}),
+		});
 
 		it("should return rule variant when rule matches", () => {
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
@@ -2161,9 +2144,7 @@ describe("Context", () => {
 		});
 
 		it("should skip environment-scoped rules when API response has no environment_id", () => {
-			const noEnvIdResponse = {
-				...envScopedRulesContextResponse,
-			};
+			const noEnvIdResponse = { ...envScopedRulesContextResponse };
 			delete noEnvIdResponse.environment_id;
 			const context = new Context(sdk, contextOptions, contextParams, noEnvIdResponse);
 			context.attribute("country", "US");
@@ -2362,38 +2343,29 @@ describe("Context", () => {
 		});
 
 		it("should invalidate cache when rule switches to a different matching variant", () => {
-			const twoRulesContextResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "US Users",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-										environments: [],
-										variant: 1,
-									},
-									{
-										name: "GB Users",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
-										environments: [],
-										variant: 2,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const twoRulesContextResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "US Users",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+							environments: [],
+							variant: 1,
+						},
+						{
+							name: "GB Users",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
+							environments: [],
+							variant: 2,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, twoRulesContextResponse);
 
 			// First: US → rule variant 1
@@ -2406,34 +2378,25 @@ describe("Context", () => {
 		});
 
 		it("should match rule with multiple and conditions", () => {
-			const multiAndResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "US Internal",
-										type: "assign",
-										conditions: { and: [
-											{ eq: [{ var: "country" }, { value: "US" }] },
-											{ eq: [{ var: "user_type" }, { value: "internal" }] },
-										] },
-										environments: [],
-										variant: 1,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const multiAndResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "US Internal",
+							type: "assign",
+							conditions: { and: [
+								{ eq: [{ var: "country" }, { value: "US" }] },
+								{ eq: [{ var: "user_type" }, { value: "internal" }] },
+							] },
+							environments: [],
+							variant: 1,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, multiAndResponse);
 
 			context.attribute("country", "US");
@@ -2445,77 +2408,58 @@ describe("Context", () => {
 		});
 
 		it("should match rule scoped to multiple environment ids", () => {
-			const multiEnvResponse = {
-				...getContextResponse,
-				environment_id: 20,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "Prod and Staging",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-										environments: [10, 20],
-										variant: 1,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const multiEnvResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "Prod and Staging",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+							environments: [10, 20],
+							variant: 1,
+						},
+					],
+				}),
+			}, { environment_id: 20 });
 			const context = new Context(sdk, contextOptions, contextParams, multiEnvResponse);
 			context.attribute("country", "US");
 			expect(context.treatment("exp_test_abc")).toEqual(1);
 		});
 
 		it("should evaluate multiple or rules and match the first", () => {
-			const multiOrResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "US Users",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-										environments: [],
-										variant: 1,
-									},
-									{
-										name: "GB Users",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
-										environments: [],
-										variant: 2,
-									},
-									{
-										name: "FR Users",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "FR" }] }] },
-										environments: [],
-										variant: 0,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const multiOrResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "US Users",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+							environments: [],
+							variant: 1,
+						},
+						{
+							name: "GB Users",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
+							environments: [],
+							variant: 2,
+						},
+						{
+							name: "FR Users",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "FR" }] }] },
+							environments: [],
+							variant: 0,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, multiOrResponse);
 
 			context.attribute("country", "US");
@@ -2532,88 +2476,61 @@ describe("Context", () => {
 		});
 
 		it("should fall back to normal assignment when rule variant is out of bounds", () => {
-			const oobResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "OOB Rule",
-										type: "assign",
-										conditions: null,
-										environments: [],
-										variant: 99,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const oobResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "OOB Rule",
+							type: "assign",
+							conditions: null,
+							environments: [],
+							variant: 99,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, oobResponse);
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
 		it("should fall back to normal assignment when rule variant is negative", () => {
-			const negResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "Negative Rule",
-										type: "assign",
-										conditions: null,
-										environments: [],
-										variant: -1,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const negResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "Negative Rule",
+							type: "assign",
+							conditions: null,
+							environments: [],
+							variant: -1,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, negResponse);
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
 		it("should set ruleOverride flag when rule forces control variant (0)", (done) => {
-			const controlRuleResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "Force Control",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-										environments: [],
-										variant: 0,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const controlRuleResponse = buildRulesResponse({
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "Force Control",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+							environments: [],
+							variant: 0,
+						},
+					],
 				}),
-			};
+			});
 			const context = new Context(sdk, contextOptions, contextParams, controlRuleResponse);
 			context.attribute("country", "US");
 			expect(context.treatment("exp_test_abc")).toEqual(0);
@@ -2635,55 +2552,37 @@ describe("Context", () => {
 		});
 
 		it("should fall back to normal assignment when assignmentRules is invalid JSON", () => {
-			const badJsonResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							assignmentRules: "not-valid-json{{{",
-						};
-					}
-					return x;
-				}),
-			};
+			const badJsonResponse = buildRulesResponse({
+				assignmentRules: "not-valid-json{{{",
+			});
 			const context = new Context(sdk, contextOptions, contextParams, badJsonResponse);
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
 		it("should not invalidate cache when out-of-range rule variant changes to a different out-of-range value", () => {
-			const oobRulesResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "OOB Rule US",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-										environments: [],
-										variant: 99,
-									},
-									{
-										name: "OOB Rule GB",
-										type: "assign",
-										conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
-										environments: [],
-										variant: 100,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const oobRulesResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "OOB Rule US",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+							environments: [],
+							variant: 99,
+						},
+						{
+							name: "OOB Rule GB",
+							type: "assign",
+							conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
+							environments: [],
+							variant: 100,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, oobRulesResponse);
 
 			context.attribute("country", "US");
@@ -2696,31 +2595,22 @@ describe("Context", () => {
 		});
 
 		it("should normalise out-of-range ruleVariant to null in cached assignment", (done) => {
-			const oobResponse = {
-				...getContextResponse,
-				experiments: getContextResponse.experiments.map((x) => {
-					if (x.name === "exp_test_abc") {
-						return {
-							...x,
-							audience: JSON.stringify({
-								filter: [{ value: true }],
-							}),
-							assignmentRules: JSON.stringify({
-								rules: [
-									{
-										name: "OOB Rule",
-										type: "assign",
-										conditions: null,
-										environments: [],
-										variant: 99,
-									},
-								],
-							}),
-						};
-					}
-					return x;
+			const oobResponse = buildRulesResponse({
+				audience: JSON.stringify({
+					filter: [{ value: true }],
 				}),
-			};
+				assignmentRules: JSON.stringify({
+					rules: [
+						{
+							name: "OOB Rule",
+							type: "assign",
+							conditions: null,
+							environments: [],
+							variant: 99,
+						},
+					],
+				}),
+			});
 			const context = new Context(sdk, contextOptions, contextParams, oobResponse);
 			context.treatment("exp_test_abc");
 

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2068,7 +2068,8 @@ describe("Context", () => {
 							rules: [
 								{
 									name: "US Internal Users",
-									and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+									type: "assign",
+									conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 									environments: [],
 									variant: 1,
 								},
@@ -2094,7 +2095,8 @@ describe("Context", () => {
 							rules: [
 								{
 									name: "Production Only",
-									and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+									type: "assign",
+									conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 									environments: [10],
 									variant: 1,
 								},
@@ -2120,7 +2122,8 @@ describe("Context", () => {
 							rules: [
 								{
 									name: "US Users",
-									and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+									type: "assign",
+									conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 									environments: [],
 									variant: 1,
 								},
@@ -2372,13 +2375,15 @@ describe("Context", () => {
 								rules: [
 									{
 										name: "US Users",
-										and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 										environments: [],
 										variant: 1,
 									},
 									{
 										name: "GB Users",
-										and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
 										environments: [],
 										variant: 2,
 									},
@@ -2414,10 +2419,11 @@ describe("Context", () => {
 								rules: [
 									{
 										name: "US Internal",
-										and: [
+										type: "assign",
+										conditions: { and: [
 											{ eq: [{ var: "country" }, { value: "US" }] },
 											{ eq: [{ var: "user_type" }, { value: "internal" }] },
-										],
+										] },
 										environments: [],
 										variant: 1,
 									},
@@ -2453,7 +2459,8 @@ describe("Context", () => {
 								rules: [
 									{
 										name: "Prod and Staging",
-										and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 										environments: [10, 20],
 										variant: 1,
 									},
@@ -2483,19 +2490,22 @@ describe("Context", () => {
 								rules: [
 									{
 										name: "US Users",
-										and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 										environments: [],
 										variant: 1,
 									},
 									{
 										name: "GB Users",
-										and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
 										environments: [],
 										variant: 2,
 									},
 									{
 										name: "FR Users",
-										and: [{ eq: [{ var: "country" }, { value: "FR" }] }],
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "FR" }] }] },
 										environments: [],
 										variant: 0,
 									},

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2038,6 +2038,160 @@ describe("Context", () => {
 		});
 	});
 
+	describe("rules evaluation", () => {
+		const rulesContextResponse = {
+			...getContextResponse,
+			experiments: getContextResponse.experiments.map((x) => {
+				if (x.name === "exp_test_ab") {
+					return {
+						...x,
+						audience: JSON.stringify({
+							filter: [{ value: true }],
+							rules: [
+								{
+									or: [
+										{
+											name: "US Internal Users",
+											and: [
+												{ eq: [{ var: "country" }, { value: "US" }] },
+											],
+											environments: [],
+											variant: 1,
+										},
+									],
+								},
+							],
+						}),
+					};
+				}
+				return x;
+			}),
+		};
+
+		const envScopedRulesContextResponse = {
+			...getContextResponse,
+			experiments: getContextResponse.experiments.map((x) => {
+				if (x.name === "exp_test_ab") {
+					return {
+						...x,
+						audience: JSON.stringify({
+							filter: [{ value: true }],
+							rules: [
+								{
+									or: [
+										{
+											name: "Production Only",
+											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+											environments: ["production"],
+											variant: 1,
+										},
+									],
+								},
+							],
+						}),
+					};
+				}
+				return x;
+			}),
+		};
+
+		const rulesStrictContextResponse = {
+			...rulesContextResponse,
+			experiments: rulesContextResponse.experiments.map((x) => {
+				if (x.name === "exp_test_ab") {
+					return {
+						...x,
+						audienceStrict: true,
+						audience: JSON.stringify({
+							filter: [{ gte: [{ var: "age" }, { value: 20 }] }],
+							rules: [
+								{
+									or: [
+										{
+											name: "US Users",
+											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+											environments: [],
+											variant: 1,
+										},
+									],
+								},
+							],
+						}),
+					};
+				}
+				return x;
+			}),
+		};
+
+		it("should return rule variant when rule matches", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_ab")).toEqual(1);
+		});
+
+		it("should return normal assignment when no rules match", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "GB");
+			expect(context.treatment("exp_test_ab")).toEqual(expectedVariants["exp_test_ab"]);
+		});
+
+		it("should skip rule when environment does not match", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("staging");
+			const context = new Context(sdk, contextOptions, contextParams, envScopedRulesContextResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_ab")).toEqual(expectedVariants["exp_test_ab"]);
+		});
+
+		it("should match rule when environment matches", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, envScopedRulesContextResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_ab")).toEqual(1);
+		});
+
+		it("should override takes priority over rules", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "US");
+			context.override("exp_test_ab", 0);
+			expect(context.treatment("exp_test_ab")).toEqual(0);
+		});
+
+		it("should set custom=true in exposure when rule matches", (done) => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_ab")).toEqual(1);
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_ab");
+				expect(exposure.custom).toBe(true);
+				expect(exposure.assigned).toBe(true);
+				expect(exposure.variant).toBe(1);
+				done();
+			});
+		});
+
+		it("rule should take priority over audienceStrict when rule matches", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_ab")).toEqual(1);
+		});
+
+		it("should fall back to audienceStrict behavior when no rule matches", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
+			context.attribute("country", "GB");
+			expect(context.treatment("exp_test_ab")).toEqual(0);
+		});
+	});
+
 	describe("variableValue()", () => {
 		it("should not return variable values when unassigned", (done) => {
 			const context = new Context(sdk, contextOptions, contextParams, audienceStrictContextResponse);

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2165,7 +2165,7 @@ describe("Context", () => {
 			expect(context.treatment("exp_test_abc")).toEqual(0);
 		});
 
-		it("should set custom=true in exposure when rule matches", (done) => {
+		it("should set overridden=true in exposure when rule matches", (done) => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
@@ -2176,7 +2176,7 @@ describe("Context", () => {
 			context.publish().then(() => {
 				const publishCall = publisher.publish.mock.calls[0][0];
 				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
-				expect(exposure.custom).toBe(true);
+				expect(exposure.overridden).toBe(true);
 				expect(exposure.assigned).toBe(true);
 				expect(exposure.variant).toBe(1);
 				done();

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2165,7 +2165,7 @@ describe("Context", () => {
 			expect(context.treatment("exp_test_abc")).toEqual(0);
 		});
 
-		it("should set overridden=true in exposure when rule matches", (done) => {
+		it("should set correct flags in exposure when rule matches", (done) => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
@@ -2176,9 +2176,91 @@ describe("Context", () => {
 			context.publish().then(() => {
 				const publishCall = publisher.publish.mock.calls[0][0];
 				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
-				expect(exposure.overridden).toBe(true);
-				expect(exposure.assigned).toBe(true);
-				expect(exposure.variant).toBe(1);
+				expect(exposure).toMatchObject({
+					id: 2,
+					name: "exp_test_abc",
+					unit: "session_id",
+					variant: 1,
+					assigned: true,
+					eligible: true,
+					overridden: true,
+					fullOn: false,
+					custom: false,
+				});
+				done();
+			});
+		});
+
+		it("should set correct flags in exposure when no rule matches (normal assignment)", (done) => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "GB");
+			expect(context.treatment("exp_test_abc")).toEqual(2);
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
+				expect(exposure).toMatchObject({
+					id: 2,
+					name: "exp_test_abc",
+					unit: "session_id",
+					variant: 2,
+					assigned: true,
+					eligible: true,
+					overridden: false,
+					fullOn: false,
+					custom: false,
+				});
+				done();
+			});
+		});
+
+		it("should set correct flags when rule matches with audienceMismatch", (done) => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
+			context.attribute("country", "US");
+			// audienceStrict on, no age set so audience filter mismatches, but rule matches
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
+				expect(exposure).toMatchObject({
+					variant: 1,
+					assigned: true,
+					eligible: true,
+					overridden: true,
+					fullOn: false,
+					custom: false,
+					audienceMismatch: true,
+				});
+				done();
+			});
+		});
+
+		it("should set correct flags when override takes priority over rule", (done) => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "US");
+			context.override("exp_test_abc", 0);
+			expect(context.treatment("exp_test_abc")).toEqual(0);
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
+				expect(exposure).toMatchObject({
+					variant: 0,
+					assigned: false,
+					overridden: true,
+					fullOn: false,
+					custom: false,
+				});
 				done();
 			});
 		});

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2193,9 +2193,9 @@ describe("Context", () => {
 					name: "exp_test_abc",
 					unit: "session_id",
 					variant: 1,
-					assigned: true,
+					assigned: false,
 					eligible: true,
-					overridden: true,
+					overridden: false,
 					fullOn: false,
 					custom: false,
 					ruleOverride: true,
@@ -2244,9 +2244,9 @@ describe("Context", () => {
 				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
 				expect(exposure).toMatchObject({
 					variant: 1,
-					assigned: true,
+					assigned: false,
 					eligible: true,
-					overridden: true,
+					overridden: false,
 					fullOn: false,
 					custom: false,
 					audienceMismatch: true,

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2339,6 +2339,61 @@ describe("Context", () => {
 			// No rule matches, audienceStrict on, audience filter mismatch — variant 0
 			expect(context.treatment("exp_test_abc")).toEqual(0);
 		});
+
+		it("should return correct variableValue when rule forces a different variant", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "US");
+			// Rule forces variant 1 (B) which has config {"button.color":"blue"}
+			// Normal assignment would be variant 2 (C) with {"button.color":"red"}
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+			expect(context.variableValue("button.color", "default")).toEqual("blue");
+		});
+
+		it("should invalidate cache when rule switches to a different matching variant", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const twoRulesContextResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+								rules: [
+									{
+										or: [
+											{
+												name: "US Users",
+												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+												environments: [],
+												variant: 1,
+											},
+											{
+												name: "GB Users",
+												and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+												environments: [],
+												variant: 2,
+											},
+										],
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, twoRulesContextResponse);
+
+			// First: US → rule variant 1
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			// Switch to GB → rule variant 2
+			context.attribute("country", "GB");
+			expect(context.treatment("exp_test_abc")).toEqual(2);
+		});
 	});
 
 	describe("variableValue()", () => {

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -764,7 +764,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 							],
 						},
@@ -879,7 +879,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 							],
 							attributes: [
@@ -1413,7 +1413,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 2,
@@ -1427,7 +1427,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 3,
@@ -1441,7 +1441,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 4,
@@ -1455,7 +1455,7 @@ describe("Context", () => {
 								fullOn: true,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 5,
@@ -1469,7 +1469,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -1538,7 +1538,7 @@ describe("Context", () => {
 					fullOn: experiment.name === "exp_test_fullon",
 					custom: false,
 					audienceMismatch: false,
-					targetingRule: false,
+					ruleOverride: false,
 				});
 			}
 
@@ -1582,7 +1582,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -1632,7 +1632,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -1674,7 +1674,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -1716,7 +1716,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -1779,7 +1779,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 0,
@@ -1793,7 +1793,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -1920,7 +1920,7 @@ describe("Context", () => {
 								name: "exp_test_ab",
 								variant: 0,
 								audienceMismatch: true,
-								targetingRule: false,
+								ruleOverride: false,
 								assigned: false,
 							}),
 						],
@@ -1946,7 +1946,7 @@ describe("Context", () => {
 									name: "exp_test_ab",
 									variant: 1,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 									assigned: true,
 								}),
 							],
@@ -2055,8 +2055,6 @@ describe("Context", () => {
 	});
 
 	describe("rules evaluation", () => {
-		// Uses exp_test_abc (3 variants, normal assignment = 2) with rules forcing variant 1
-		// This ensures tests are meaningful: rule variant (1) differs from normal assignment (2)
 		const rulesContextResponse = {
 			...getContextResponse,
 			experiments: getContextResponse.experiments.map((x) => {
@@ -2200,7 +2198,7 @@ describe("Context", () => {
 					overridden: true,
 					fullOn: false,
 					custom: false,
-					targetingRule: true,
+					ruleOverride: true,
 				});
 				done();
 			});
@@ -2227,7 +2225,7 @@ describe("Context", () => {
 					overridden: false,
 					fullOn: false,
 					custom: false,
-					targetingRule: false,
+					ruleOverride: false,
 				});
 				done();
 			});
@@ -2252,7 +2250,7 @@ describe("Context", () => {
 					fullOn: false,
 					custom: false,
 					audienceMismatch: true,
-					targetingRule: true,
+					ruleOverride: true,
 				});
 				done();
 			});
@@ -2276,7 +2274,7 @@ describe("Context", () => {
 					overridden: true,
 					fullOn: false,
 					custom: false,
-					targetingRule: false,
+					ruleOverride: false,
 				});
 				done();
 			});
@@ -2303,7 +2301,7 @@ describe("Context", () => {
 					variant: 1,
 					assigned: false,
 					overridden: true,
-					targetingRule: false,
+					ruleOverride: false,
 				});
 				done();
 			});
@@ -2409,6 +2407,135 @@ describe("Context", () => {
 			context.attribute("country", "GB");
 			expect(context.treatment("exp_test_abc")).toEqual(2);
 		});
+
+		it("should match rule with multiple and conditions", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const multiAndResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+								rules: [
+									{
+										or: [
+											{
+												name: "US Internal",
+												and: [
+													{ eq: [{ var: "country" }, { value: "US" }] },
+													{ eq: [{ var: "user_type" }, { value: "internal" }] },
+												],
+												environments: [],
+												variant: 1,
+											},
+										],
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, multiAndResponse);
+
+			context.attribute("country", "US");
+			context.attribute("user_type", "internal");
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			context.attribute("user_type", "external");
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
+
+		it("should match rule scoped to multiple environments", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("staging");
+			const multiEnvResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+								rules: [
+									{
+										or: [
+											{
+												name: "Prod and Staging",
+												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+												environments: ["production", "staging"],
+												variant: 1,
+											},
+										],
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, multiEnvResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+		});
+
+		it("should evaluate multiple or rules and match the first", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const multiOrResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+								rules: [
+									{
+										or: [
+											{
+												name: "US Users",
+												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+												environments: [],
+												variant: 1,
+											},
+											{
+												name: "GB Users",
+												and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+												environments: [],
+												variant: 2,
+											},
+											{
+												name: "FR Users",
+												and: [{ eq: [{ var: "country" }, { value: "FR" }] }],
+												environments: [],
+												variant: 0,
+											},
+										],
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, multiOrResponse);
+
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			context.attribute("country", "GB");
+			expect(context.treatment("exp_test_abc")).toEqual(2);
+
+			context.attribute("country", "FR");
+			expect(context.treatment("exp_test_abc")).toEqual(0);
+
+			context.attribute("country", "DE");
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
 	});
 
 	describe("variableValue()", () => {
@@ -2492,7 +2619,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 2,
@@ -2506,7 +2633,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 3,
@@ -2520,7 +2647,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 4,
@@ -2534,7 +2661,7 @@ describe("Context", () => {
 								fullOn: true,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 5,
@@ -2548,7 +2675,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -2662,7 +2789,7 @@ describe("Context", () => {
 							fullOn: experiment.name === "exp_test_fullon",
 							custom: false,
 							audienceMismatch: false,
-							targetingRule: false,
+							ruleOverride: false,
 						});
 					} else {
 						expect(SDK.defaultEventLogger).not.toHaveBeenCalled();
@@ -2729,7 +2856,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -2771,7 +2898,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -2813,7 +2940,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -3254,7 +3381,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 3,
@@ -3268,7 +3395,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 						goals: [
@@ -3493,7 +3620,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 								{
 									id: 0,
@@ -3507,7 +3634,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 								{
 									id: 2,
@@ -3521,7 +3648,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: true,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 							],
 							goals: [
@@ -3757,7 +3884,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -3809,7 +3936,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -4010,7 +4137,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 								{
 									id: 2,
@@ -4024,7 +4151,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 							],
 						},
@@ -4074,7 +4201,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: true,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -4123,7 +4250,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 							{
 								id: 4,
@@ -4137,7 +4264,7 @@ describe("Context", () => {
 								fullOn: true,
 								custom: false,
 								audienceMismatch: false,
-								targetingRule: false,
+								ruleOverride: false,
 							},
 						],
 					},
@@ -4195,7 +4322,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: true,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 								{
 									id: 2,
@@ -4209,7 +4336,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: true,
 									audienceMismatch: false,
-									targetingRule: false,
+									ruleOverride: false,
 								},
 							],
 						},

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2067,14 +2067,10 @@ describe("Context", () => {
 						assignment_rules: JSON.stringify({
 							rules: [
 								{
-									or: [
-										{
-											name: "US Internal Users",
-											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-											environments: [],
-											variant: 1,
-										},
-									],
+									name: "US Internal Users",
+									and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+									environments: [],
+									variant: 1,
 								},
 							],
 						}),
@@ -2097,14 +2093,10 @@ describe("Context", () => {
 						assignment_rules: JSON.stringify({
 							rules: [
 								{
-									or: [
-										{
-											name: "Production Only",
-											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-											environments: [10],
-											variant: 1,
-										},
-									],
+									name: "Production Only",
+									and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+									environments: [10],
+									variant: 1,
 								},
 							],
 						}),
@@ -2127,14 +2119,10 @@ describe("Context", () => {
 						assignment_rules: JSON.stringify({
 							rules: [
 								{
-									or: [
-										{
-											name: "US Users",
-											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-											environments: [],
-											variant: 1,
-										},
-									],
+									name: "US Users",
+									and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+									environments: [],
+									variant: 1,
 								},
 							],
 						}),
@@ -2383,20 +2371,16 @@ describe("Context", () => {
 							assignment_rules: JSON.stringify({
 								rules: [
 									{
-										or: [
-											{
-												name: "US Users",
-												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-												environments: [],
-												variant: 1,
-											},
-											{
-												name: "GB Users",
-												and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
-												environments: [],
-												variant: 2,
-											},
-										],
+										name: "US Users",
+										and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+										environments: [],
+										variant: 1,
+									},
+									{
+										name: "GB Users",
+										and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+										environments: [],
+										variant: 2,
 									},
 								],
 							}),
@@ -2429,17 +2413,13 @@ describe("Context", () => {
 							assignment_rules: JSON.stringify({
 								rules: [
 									{
-										or: [
-											{
-												name: "US Internal",
-												and: [
-													{ eq: [{ var: "country" }, { value: "US" }] },
-													{ eq: [{ var: "user_type" }, { value: "internal" }] },
-												],
-												environments: [],
-												variant: 1,
-											},
+										name: "US Internal",
+										and: [
+											{ eq: [{ var: "country" }, { value: "US" }] },
+											{ eq: [{ var: "user_type" }, { value: "internal" }] },
 										],
+										environments: [],
+										variant: 1,
 									},
 								],
 							}),
@@ -2472,14 +2452,10 @@ describe("Context", () => {
 							assignment_rules: JSON.stringify({
 								rules: [
 									{
-										or: [
-											{
-												name: "Prod and Staging",
-												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-												environments: [10, 20],
-												variant: 1,
-											},
-										],
+										name: "Prod and Staging",
+										and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+										environments: [10, 20],
+										variant: 1,
 									},
 								],
 							}),
@@ -2506,26 +2482,22 @@ describe("Context", () => {
 							assignment_rules: JSON.stringify({
 								rules: [
 									{
-										or: [
-											{
-												name: "US Users",
-												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-												environments: [],
-												variant: 1,
-											},
-											{
-												name: "GB Users",
-												and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
-												environments: [],
-												variant: 2,
-											},
-											{
-												name: "FR Users",
-												and: [{ eq: [{ var: "country" }, { value: "FR" }] }],
-												environments: [],
-												variant: 0,
-											},
-										],
+										name: "US Users",
+										and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+										environments: [],
+										variant: 1,
+									},
+									{
+										name: "GB Users",
+										and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+										environments: [],
+										variant: 2,
+									},
+									{
+										name: "FR Users",
+										and: [{ eq: [{ var: "country" }, { value: "FR" }] }],
+										environments: [],
+										variant: 0,
 									},
 								],
 							}),

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2265,6 +2265,35 @@ describe("Context", () => {
 			});
 		});
 
+		it("should invalidate cached assignment when rule result changes due to attribute change", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+
+			// First call: no country set, rule doesn't match → normal assignment (2)
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+
+			// Change attribute so rule now matches
+			context.attribute("country", "US");
+
+			// Second call: rule matches → should return rule variant (1), not cached (2)
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+		});
+
+		it("should invalidate cached assignment when rule stops matching due to attribute change", () => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+
+			// First call: country=US, rule matches → variant 1
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			// Change attribute so rule no longer matches
+			context.attribute("country", "GB");
+
+			// Second call: rule no longer matches → should return normal assignment (2)
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
+
 		it("rule should take priority over audienceStrict when rule matches", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2084,6 +2084,7 @@ describe("Context", () => {
 
 		const envScopedRulesContextResponse = {
 			...getContextResponse,
+			environment_id: 10,
 			experiments: getContextResponse.experiments.map((x) => {
 				if (x.name === "exp_test_abc") {
 					return {
@@ -2096,7 +2097,7 @@ describe("Context", () => {
 										{
 											name: "Production Only",
 											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-											environments: ["production"],
+											environments: [10],
 											variant: 1,
 										},
 									],
@@ -2138,7 +2139,6 @@ describe("Context", () => {
 		};
 
 		it("should return rule variant when rule matches", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 			// Normal assignment would return 2, rules force variant 1
@@ -2146,31 +2146,42 @@ describe("Context", () => {
 		});
 
 		it("should return normal assignment when no rules match", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "GB");
 			// No rule matches, should get normal assignment (2)
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
-		it("should skip rule when environment does not match", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("staging");
-			const context = new Context(sdk, contextOptions, contextParams, envScopedRulesContextResponse);
+		it("should skip rule when environment id does not match", () => {
+			const stagingResponse = {
+				...envScopedRulesContextResponse,
+				environment_id: 20,
+			};
+			const context = new Context(sdk, contextOptions, contextParams, stagingResponse);
 			context.attribute("country", "US");
-			// Rule scoped to production, SDK is staging — should get normal assignment (2)
+			// Rule scoped to env 10, context has env 20 — should get normal assignment (2)
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
-		it("should match rule when environment matches", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
+		it("should skip environment-scoped rules when API response has no environment_id", () => {
+			const noEnvIdResponse = {
+				...envScopedRulesContextResponse,
+			};
+			delete noEnvIdResponse.environment_id;
+			const context = new Context(sdk, contextOptions, contextParams, noEnvIdResponse);
+			context.attribute("country", "US");
+			// Rule requires env 10, but no environment_id in response — should get normal assignment
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
+
+		it("should match rule when environment id matches", () => {
 			const context = new Context(sdk, contextOptions, contextParams, envScopedRulesContextResponse);
 			context.attribute("country", "US");
-			// Rule scoped to production, SDK is production — should get rule variant (1)
+			// Rule scoped to env 10, context has env 10 — should get rule variant (1)
 			expect(context.treatment("exp_test_abc")).toEqual(1);
 		});
 
 		it("should override takes priority over rules", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 			context.override("exp_test_abc", 0);
@@ -2178,7 +2189,6 @@ describe("Context", () => {
 		});
 
 		it("should set correct flags in exposure when rule matches", (done) => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 			expect(context.treatment("exp_test_abc")).toEqual(1);
@@ -2205,7 +2215,6 @@ describe("Context", () => {
 		});
 
 		it("should set correct flags in exposure when no rule matches (normal assignment)", (done) => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "GB");
 			expect(context.treatment("exp_test_abc")).toEqual(2);
@@ -2232,7 +2241,6 @@ describe("Context", () => {
 		});
 
 		it("should set correct flags when rule matches with audienceMismatch", (done) => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
 			context.attribute("country", "US");
 			expect(context.treatment("exp_test_abc")).toEqual(1);
@@ -2257,7 +2265,6 @@ describe("Context", () => {
 		});
 
 		it("should set correct flags when override takes priority over rule", (done) => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 			context.override("exp_test_abc", 0);
@@ -2281,7 +2288,6 @@ describe("Context", () => {
 		});
 
 		it("should set correct override flags even when override variant matches rule variant", (done) => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 
@@ -2308,7 +2314,6 @@ describe("Context", () => {
 		});
 
 		it("should invalidate cached assignment when rule result changes due to attribute change", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 
 			// First call: no country set, rule doesn't match → normal assignment (2)
@@ -2322,7 +2327,6 @@ describe("Context", () => {
 		});
 
 		it("should invalidate cached assignment when rule stops matching due to attribute change", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 
 			// First call: country=US, rule matches → variant 1
@@ -2337,7 +2341,6 @@ describe("Context", () => {
 		});
 
 		it("rule should take priority over audienceStrict when rule matches", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
 			context.attribute("country", "US");
 			// audienceStrict is on, user doesn't match audience filter (no age set),
@@ -2346,7 +2349,6 @@ describe("Context", () => {
 		});
 
 		it("should fall back to audienceStrict behavior when no rule matches", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
 			context.attribute("country", "GB");
 			// No rule matches, audienceStrict on, audience filter mismatch — variant 0
@@ -2354,7 +2356,6 @@ describe("Context", () => {
 		});
 
 		it("should return correct variableValue when rule forces a different variant", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 			// Rule forces variant 1 (B) which has config {"button.color":"blue"}
@@ -2364,7 +2365,6 @@ describe("Context", () => {
 		});
 
 		it("should invalidate cache when rule switches to a different matching variant", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const twoRulesContextResponse = {
 				...getContextResponse,
 				experiments: getContextResponse.experiments.map((x) => {
@@ -2409,7 +2409,6 @@ describe("Context", () => {
 		});
 
 		it("should match rule with multiple and conditions", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const multiAndResponse = {
 				...getContextResponse,
 				experiments: getContextResponse.experiments.map((x) => {
@@ -2449,10 +2448,10 @@ describe("Context", () => {
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
-		it("should match rule scoped to multiple environments", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("staging");
+		it("should match rule scoped to multiple environment ids", () => {
 			const multiEnvResponse = {
 				...getContextResponse,
+				environment_id: 20,
 				experiments: getContextResponse.experiments.map((x) => {
 					if (x.name === "exp_test_abc") {
 						return {
@@ -2465,7 +2464,7 @@ describe("Context", () => {
 											{
 												name: "Prod and Staging",
 												and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-												environments: ["production", "staging"],
+												environments: [10, 20],
 												variant: 1,
 											},
 										],
@@ -2483,7 +2482,6 @@ describe("Context", () => {
 		});
 
 		it("should evaluate multiple or rules and match the first", () => {
-			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const multiOrResponse = {
 				...getContextResponse,
 				experiments: getContextResponse.experiments.map((x) => {

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2039,10 +2039,12 @@ describe("Context", () => {
 	});
 
 	describe("rules evaluation", () => {
+		// Uses exp_test_abc (3 variants, normal assignment = 2) with rules forcing variant 1
+		// This ensures tests are meaningful: rule variant (1) differs from normal assignment (2)
 		const rulesContextResponse = {
 			...getContextResponse,
 			experiments: getContextResponse.experiments.map((x) => {
-				if (x.name === "exp_test_ab") {
+				if (x.name === "exp_test_abc") {
 					return {
 						...x,
 						audience: JSON.stringify({
@@ -2071,7 +2073,7 @@ describe("Context", () => {
 		const envScopedRulesContextResponse = {
 			...getContextResponse,
 			experiments: getContextResponse.experiments.map((x) => {
-				if (x.name === "exp_test_ab") {
+				if (x.name === "exp_test_abc") {
 					return {
 						...x,
 						audience: JSON.stringify({
@@ -2096,9 +2098,9 @@ describe("Context", () => {
 		};
 
 		const rulesStrictContextResponse = {
-			...rulesContextResponse,
-			experiments: rulesContextResponse.experiments.map((x) => {
-				if (x.name === "exp_test_ab") {
+			...getContextResponse,
+			experiments: getContextResponse.experiments.map((x) => {
+				if (x.name === "exp_test_abc") {
 					return {
 						...x,
 						audienceStrict: true,
@@ -2127,49 +2129,53 @@ describe("Context", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
-			expect(context.treatment("exp_test_ab")).toEqual(1);
+			// Normal assignment would return 2, rules force variant 1
+			expect(context.treatment("exp_test_abc")).toEqual(1);
 		});
 
 		it("should return normal assignment when no rules match", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "GB");
-			expect(context.treatment("exp_test_ab")).toEqual(expectedVariants["exp_test_ab"]);
+			// No rule matches, should get normal assignment (2)
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
 		it("should skip rule when environment does not match", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("staging");
 			const context = new Context(sdk, contextOptions, contextParams, envScopedRulesContextResponse);
 			context.attribute("country", "US");
-			expect(context.treatment("exp_test_ab")).toEqual(expectedVariants["exp_test_ab"]);
+			// Rule scoped to production, SDK is staging — should get normal assignment (2)
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 
 		it("should match rule when environment matches", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, envScopedRulesContextResponse);
 			context.attribute("country", "US");
-			expect(context.treatment("exp_test_ab")).toEqual(1);
+			// Rule scoped to production, SDK is production — should get rule variant (1)
+			expect(context.treatment("exp_test_abc")).toEqual(1);
 		});
 
 		it("should override takes priority over rules", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
-			context.override("exp_test_ab", 0);
-			expect(context.treatment("exp_test_ab")).toEqual(0);
+			context.override("exp_test_abc", 0);
+			expect(context.treatment("exp_test_abc")).toEqual(0);
 		});
 
 		it("should set custom=true in exposure when rule matches", (done) => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
-			expect(context.treatment("exp_test_ab")).toEqual(1);
+			expect(context.treatment("exp_test_abc")).toEqual(1);
 
 			publisher.publish.mockReturnValue(Promise.resolve());
 
 			context.publish().then(() => {
 				const publishCall = publisher.publish.mock.calls[0][0];
-				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_ab");
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
 				expect(exposure.custom).toBe(true);
 				expect(exposure.assigned).toBe(true);
 				expect(exposure.variant).toBe(1);
@@ -2181,14 +2187,17 @@ describe("Context", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
 			context.attribute("country", "US");
-			expect(context.treatment("exp_test_ab")).toEqual(1);
+			// audienceStrict is on, user doesn't match audience filter (no age set),
+			// but rule matches — should still get rule variant (1)
+			expect(context.treatment("exp_test_abc")).toEqual(1);
 		});
 
 		it("should fall back to audienceStrict behavior when no rule matches", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
 			context.attribute("country", "GB");
-			expect(context.treatment("exp_test_ab")).toEqual(0);
+			// No rule matches, audienceStrict on, audience filter mismatch — variant 0
+			expect(context.treatment("exp_test_abc")).toEqual(0);
 		});
 	});
 

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2265,6 +2265,35 @@ describe("Context", () => {
 			});
 		});
 
+		it("should set correct override flags even when override variant matches rule variant", (done) => {
+			client.getEnvironment = jest.fn().mockReturnValue("production");
+			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
+			context.attribute("country", "US");
+
+			// First call: rule matches → variant 1 with assigned=true, overridden=true
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			// Now override with the same variant the rule assigned
+			context.override("exp_test_abc", 1);
+
+			// Second call: override should take over with assigned=false
+			expect(context.treatment("exp_test_abc")).toEqual(1);
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposures = publishCall.exposures.filter((e) => e.name === "exp_test_abc");
+				const lastExposure = exposures[exposures.length - 1];
+				expect(lastExposure).toMatchObject({
+					variant: 1,
+					assigned: false,
+					overridden: true,
+				});
+				done();
+			});
+		});
+
 		it("should invalidate cached assignment when rule result changes due to attribute change", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2063,6 +2063,8 @@ describe("Context", () => {
 						...x,
 						audience: JSON.stringify({
 							filter: [{ value: true }],
+						}),
+						assignment_rules: JSON.stringify({
 							rules: [
 								{
 									or: [
@@ -2091,6 +2093,8 @@ describe("Context", () => {
 						...x,
 						audience: JSON.stringify({
 							filter: [{ value: true }],
+						}),
+						assignment_rules: JSON.stringify({
 							rules: [
 								{
 									or: [
@@ -2119,6 +2123,8 @@ describe("Context", () => {
 						audienceStrict: true,
 						audience: JSON.stringify({
 							filter: [{ gte: [{ var: "age" }, { value: 20 }] }],
+						}),
+						assignment_rules: JSON.stringify({
 							rules: [
 								{
 									or: [
@@ -2373,6 +2379,8 @@ describe("Context", () => {
 							...x,
 							audience: JSON.stringify({
 								filter: [{ value: true }],
+							}),
+							assignment_rules: JSON.stringify({
 								rules: [
 									{
 										or: [
@@ -2417,6 +2425,8 @@ describe("Context", () => {
 							...x,
 							audience: JSON.stringify({
 								filter: [{ value: true }],
+							}),
+							assignment_rules: JSON.stringify({
 								rules: [
 									{
 										or: [
@@ -2458,6 +2468,8 @@ describe("Context", () => {
 							...x,
 							audience: JSON.stringify({
 								filter: [{ value: true }],
+							}),
+							assignment_rules: JSON.stringify({
 								rules: [
 									{
 										or: [
@@ -2490,6 +2502,8 @@ describe("Context", () => {
 							...x,
 							audience: JSON.stringify({
 								filter: [{ value: true }],
+							}),
+							assignment_rules: JSON.stringify({
 								rules: [
 									{
 										or: [

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -764,6 +764,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 							],
 						},
@@ -878,6 +879,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 							],
 							attributes: [
@@ -1411,6 +1413,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 2,
@@ -1424,6 +1427,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 3,
@@ -1437,6 +1441,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 4,
@@ -1450,6 +1455,7 @@ describe("Context", () => {
 								fullOn: true,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 5,
@@ -1463,6 +1469,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -1531,6 +1538,7 @@ describe("Context", () => {
 					fullOn: experiment.name === "exp_test_fullon",
 					custom: false,
 					audienceMismatch: false,
+					targetingRule: false,
 				});
 			}
 
@@ -1574,6 +1582,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -1623,6 +1632,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -1664,6 +1674,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
+								targetingRule: false,
 							},
 						],
 					},
@@ -1705,6 +1716,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
+								targetingRule: false,
 							},
 						],
 					},
@@ -1767,6 +1779,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 0,
@@ -1780,6 +1793,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -1906,6 +1920,7 @@ describe("Context", () => {
 								name: "exp_test_ab",
 								variant: 0,
 								audienceMismatch: true,
+								targetingRule: false,
 								assigned: false,
 							}),
 						],
@@ -1931,6 +1946,7 @@ describe("Context", () => {
 									name: "exp_test_ab",
 									variant: 1,
 									audienceMismatch: false,
+									targetingRule: false,
 									assigned: true,
 								}),
 							],
@@ -2054,9 +2070,7 @@ describe("Context", () => {
 									or: [
 										{
 											name: "US Internal Users",
-											and: [
-												{ eq: [{ var: "country" }, { value: "US" }] },
-											],
+											and: [{ eq: [{ var: "country" }, { value: "US" }] }],
 											environments: [],
 											variant: 1,
 										},
@@ -2186,6 +2200,7 @@ describe("Context", () => {
 					overridden: true,
 					fullOn: false,
 					custom: false,
+					targetingRule: true,
 				});
 				done();
 			});
@@ -2212,6 +2227,7 @@ describe("Context", () => {
 					overridden: false,
 					fullOn: false,
 					custom: false,
+					targetingRule: false,
 				});
 				done();
 			});
@@ -2221,7 +2237,6 @@ describe("Context", () => {
 			client.getEnvironment = jest.fn().mockReturnValue("production");
 			const context = new Context(sdk, contextOptions, contextParams, rulesStrictContextResponse);
 			context.attribute("country", "US");
-			// audienceStrict on, no age set so audience filter mismatches, but rule matches
 			expect(context.treatment("exp_test_abc")).toEqual(1);
 
 			publisher.publish.mockReturnValue(Promise.resolve());
@@ -2237,6 +2252,7 @@ describe("Context", () => {
 					fullOn: false,
 					custom: false,
 					audienceMismatch: true,
+					targetingRule: true,
 				});
 				done();
 			});
@@ -2260,6 +2276,7 @@ describe("Context", () => {
 					overridden: true,
 					fullOn: false,
 					custom: false,
+					targetingRule: false,
 				});
 				done();
 			});
@@ -2270,13 +2287,10 @@ describe("Context", () => {
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 
-			// First call: rule matches → variant 1 with assigned=true, overridden=true
 			expect(context.treatment("exp_test_abc")).toEqual(1);
 
-			// Now override with the same variant the rule assigned
 			context.override("exp_test_abc", 1);
 
-			// Second call: override should take over with assigned=false
 			expect(context.treatment("exp_test_abc")).toEqual(1);
 
 			publisher.publish.mockReturnValue(Promise.resolve());
@@ -2289,6 +2303,7 @@ describe("Context", () => {
 					variant: 1,
 					assigned: false,
 					overridden: true,
+					targetingRule: false,
 				});
 				done();
 			});
@@ -2477,6 +2492,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 2,
@@ -2490,6 +2506,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 3,
@@ -2503,6 +2520,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 4,
@@ -2516,6 +2534,7 @@ describe("Context", () => {
 								fullOn: true,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 5,
@@ -2529,6 +2548,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -2642,6 +2662,7 @@ describe("Context", () => {
 							fullOn: experiment.name === "exp_test_fullon",
 							custom: false,
 							audienceMismatch: false,
+							targetingRule: false,
 						});
 					} else {
 						expect(SDK.defaultEventLogger).not.toHaveBeenCalled();
@@ -2708,6 +2729,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -2749,6 +2771,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
+								targetingRule: false,
 							},
 						],
 					},
@@ -2790,6 +2813,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: true,
+								targetingRule: false,
 							},
 						],
 					},
@@ -3230,6 +3254,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 3,
@@ -3243,6 +3268,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 						goals: [
@@ -3467,6 +3493,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 								{
 									id: 0,
@@ -3480,6 +3507,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 								{
 									id: 2,
@@ -3493,6 +3521,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: true,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 							],
 							goals: [
@@ -3728,6 +3757,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -3779,6 +3809,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -3979,6 +4010,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 								{
 									id: 2,
@@ -3992,6 +4024,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: false,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 							],
 						},
@@ -4041,6 +4074,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: true,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -4089,6 +4123,7 @@ describe("Context", () => {
 								fullOn: false,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 							{
 								id: 4,
@@ -4102,6 +4137,7 @@ describe("Context", () => {
 								fullOn: true,
 								custom: false,
 								audienceMismatch: false,
+								targetingRule: false,
 							},
 						],
 					},
@@ -4159,6 +4195,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: true,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 								{
 									id: 2,
@@ -4172,6 +4209,7 @@ describe("Context", () => {
 									fullOn: false,
 									custom: true,
 									audienceMismatch: false,
+									targetingRule: false,
 								},
 							],
 						},

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2064,7 +2064,7 @@ describe("Context", () => {
 						audience: JSON.stringify({
 							filter: [{ value: true }],
 						}),
-						assignment_rules: JSON.stringify({
+						assignmentRules: JSON.stringify({
 							rules: [
 								{
 									name: "US Internal Users",
@@ -2091,7 +2091,7 @@ describe("Context", () => {
 						audience: JSON.stringify({
 							filter: [{ value: true }],
 						}),
-						assignment_rules: JSON.stringify({
+						assignmentRules: JSON.stringify({
 							rules: [
 								{
 									name: "Production Only",
@@ -2118,7 +2118,7 @@ describe("Context", () => {
 						audience: JSON.stringify({
 							filter: [{ gte: [{ var: "age" }, { value: 20 }] }],
 						}),
-						assignment_rules: JSON.stringify({
+						assignmentRules: JSON.stringify({
 							rules: [
 								{
 									name: "US Users",
@@ -2178,7 +2178,7 @@ describe("Context", () => {
 			expect(context.treatment("exp_test_abc")).toEqual(1);
 		});
 
-		it("should override takes priority over rules", () => {
+		it("override should take priority over rules", () => {
 			const context = new Context(sdk, contextOptions, contextParams, rulesContextResponse);
 			context.attribute("country", "US");
 			context.override("exp_test_abc", 0);
@@ -2371,7 +2371,7 @@ describe("Context", () => {
 							audience: JSON.stringify({
 								filter: [{ value: true }],
 							}),
-							assignment_rules: JSON.stringify({
+							assignmentRules: JSON.stringify({
 								rules: [
 									{
 										name: "US Users",
@@ -2415,7 +2415,7 @@ describe("Context", () => {
 							audience: JSON.stringify({
 								filter: [{ value: true }],
 							}),
-							assignment_rules: JSON.stringify({
+							assignmentRules: JSON.stringify({
 								rules: [
 									{
 										name: "US Internal",
@@ -2455,7 +2455,7 @@ describe("Context", () => {
 							audience: JSON.stringify({
 								filter: [{ value: true }],
 							}),
-							assignment_rules: JSON.stringify({
+							assignmentRules: JSON.stringify({
 								rules: [
 									{
 										name: "Prod and Staging",
@@ -2486,7 +2486,7 @@ describe("Context", () => {
 							audience: JSON.stringify({
 								filter: [{ value: true }],
 							}),
-							assignment_rules: JSON.stringify({
+							assignmentRules: JSON.stringify({
 								rules: [
 									{
 										name: "US Users",
@@ -2528,6 +2528,126 @@ describe("Context", () => {
 			expect(context.treatment("exp_test_abc")).toEqual(0);
 
 			context.attribute("country", "DE");
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
+
+		it("should fall back to normal assignment when rule variant is out of bounds", () => {
+			const oobResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+							}),
+							assignmentRules: JSON.stringify({
+								rules: [
+									{
+										name: "OOB Rule",
+										type: "assign",
+										conditions: null,
+										environments: [],
+										variant: 99,
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, oobResponse);
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
+
+		it("should fall back to normal assignment when rule variant is negative", () => {
+			const negResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							audience: JSON.stringify({
+								filter: [{ value: true }],
+							}),
+							assignmentRules: JSON.stringify({
+								rules: [
+									{
+										name: "Negative Rule",
+										type: "assign",
+										conditions: null,
+										environments: [],
+										variant: -1,
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, negResponse);
+			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
+		});
+
+		it("should set ruleOverride flag when rule forces control variant (0)", (done) => {
+			const controlRuleResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							assignmentRules: JSON.stringify({
+								rules: [
+									{
+										name: "Force Control",
+										type: "assign",
+										conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
+										environments: [],
+										variant: 0,
+									},
+								],
+							}),
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, controlRuleResponse);
+			context.attribute("country", "US");
+			expect(context.treatment("exp_test_abc")).toEqual(0);
+
+			publisher.publish.mockReturnValue(Promise.resolve());
+
+			context.publish().then(() => {
+				const publishCall = publisher.publish.mock.calls[0][0];
+				const exposure = publishCall.exposures.find((e) => e.name === "exp_test_abc");
+				expect(exposure).toMatchObject({
+					variant: 0,
+					assigned: false,
+					eligible: true,
+					overridden: false,
+					ruleOverride: true,
+				});
+				done();
+			});
+		});
+
+		it("should fall back to normal assignment when assignmentRules is invalid JSON", () => {
+			const badJsonResponse = {
+				...getContextResponse,
+				experiments: getContextResponse.experiments.map((x) => {
+					if (x.name === "exp_test_abc") {
+						return {
+							...x,
+							assignmentRules: "not-valid-json{{{",
+						};
+					}
+					return x;
+				}),
+			};
+			const context = new Context(sdk, contextOptions, contextParams, badJsonResponse);
 			expect(context.treatment("exp_test_abc")).toEqual(expectedVariants["exp_test_abc"]);
 		});
 	});

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -40,14 +40,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [],
-								variant: 1,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [],
+						variant: 1,
 					},
 				],
 			});
@@ -58,14 +54,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [],
-								variant: 1,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [],
+						variant: 1,
 					},
 				],
 			});
@@ -76,14 +68,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [2],
-								variant: 1,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [2],
+						variant: 1,
 					},
 				],
 			});
@@ -94,14 +82,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [1, 2],
-								variant: 2,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [1, 2],
+						variant: 2,
 					},
 				],
 			});
@@ -113,14 +97,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ value: true }],
-								environments: [],
-								variant: 1,
-							},
-						],
+						name: "rule1",
+						and: [{ value: true }],
+						environments: [],
+						variant: 1,
 					},
 				],
 			});
@@ -133,14 +113,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ value: true }],
-								environments: [1],
-								variant: 1,
-							},
-						],
+						name: "rule1",
+						and: [{ value: true }],
+						environments: [1],
+						variant: 1,
 					},
 				],
 			});
@@ -151,20 +127,16 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [],
-								variant: 1,
-							},
-							{
-								name: "rule2",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [],
-								variant: 2,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [],
+						variant: 1,
+					},
+					{
+						name: "rule2",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [],
+						variant: 2,
 					},
 				],
 			});
@@ -175,14 +147,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [],
-								environments: [],
-								variant: 3,
-							},
-						],
+						name: "rule1",
+						and: [],
+						environments: [],
+						variant: 3,
 					},
 				],
 			});
@@ -193,13 +161,9 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								environments: [],
-								variant: 3,
-							},
-						],
+						name: "rule1",
+						environments: [],
+						variant: 3,
 					},
 				],
 			});
@@ -215,13 +179,9 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [],
-								environments: [],
-							},
-						],
+						name: "rule1",
+						and: [],
+						environments: [],
 					},
 				],
 			});
@@ -232,14 +192,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [],
-								environments: [],
-								variant: "bad",
-							},
-						],
+						name: "rule1",
+						and: [],
+						environments: [],
+						variant: "bad",
 					},
 				],
 			});
@@ -250,20 +206,16 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "bad rule",
-								and: [],
-								environments: [],
-								variant: "not a number",
-							},
-							{
-								name: "good rule",
-								and: [],
-								environments: [],
-								variant: 2,
-							},
-						],
+						name: "bad rule",
+						and: [],
+						environments: [],
+						variant: "not a number",
+					},
+					{
+						name: "good rule",
+						and: [],
+						environments: [],
+						variant: 2,
 					},
 				],
 			});
@@ -274,19 +226,15 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "no variant",
-								and: [],
-								environments: [],
-							},
-							{
-								name: "good rule",
-								and: [],
-								environments: [],
-								variant: 1,
-							},
-						],
+						name: "no variant",
+						and: [],
+						environments: [],
+					},
+					{
+						name: "good rule",
+						and: [],
+						environments: [],
+						variant: 1,
 					},
 				],
 			});
@@ -295,7 +243,6 @@ describe("AudienceMatcher", () => {
 
 		it("should handle malformed rules gracefully", () => {
 			expect(matcher.evaluateRules('{"rules":"not an array"}', 1, {})).toBe(null);
-			expect(matcher.evaluateRules('{"rules":[{"or":"not an array"}]}', 1, {})).toBe(null);
 			expect(matcher.evaluateRules('{"rules":[null]}', 1, {})).toBe(null);
 		});
 
@@ -303,48 +250,36 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
-								environments: [],
-								variant: 1,
-							},
-							{
-								name: "rule2",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [],
-								variant: 2,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+						environments: [],
+						variant: 1,
+					},
+					{
+						name: "rule2",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [],
+						variant: 2,
 					},
 				],
 			});
 			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(2);
 		});
 
-		it("should evaluate second rule group when first has no match", () => {
+		it("should skip to later rule when earlier rules do not match", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
-								environments: [],
-								variant: 1,
-							},
-						],
+						name: "rule1",
+						and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+						environments: [],
+						variant: 1,
 					},
 					{
-						or: [
-							{
-								name: "rule2",
-								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: [],
-								variant: 2,
-							},
-						],
+						name: "rule2",
+						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						environments: [],
+						variant: 2,
 					},
 				],
 			});
@@ -355,14 +290,10 @@ describe("AudienceMatcher", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
-						or: [
-							{
-								name: "rule1",
-								and: [{ value: true }],
-								environments: [],
-								variant: 0,
-							},
-						],
+						name: "rule1",
+						and: [{ value: true }],
+						environments: [],
+						variant: 0,
 					},
 				],
 			});

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -311,28 +311,6 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(2);
 		});
 
-		it("should skip to later rule when earlier rules do not match", () => {
-			const audience = JSON.stringify({
-				rules: [
-					{
-						name: "rule1",
-						type: "assign",
-						conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
-						environments: [],
-						variant: 1,
-					},
-					{
-						name: "rule2",
-						type: "assign",
-						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
-						environments: [],
-						variant: 2,
-					},
-				],
-			});
-			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(2);
-		});
-
 		it("should support variant 0", () => {
 			const audience = JSON.stringify({
 				rules: [
@@ -346,6 +324,26 @@ describe("AudienceMatcher", () => {
 				],
 			});
 			expect(matcher.evaluateRules(audience, 1, {})).toBe(0);
+		});
+
+		it("should skip rule with fractional variant", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						environments: [],
+						variant: 1.5,
+					},
+					{
+						name: "rule2",
+						type: "assign",
+						environments: [],
+						variant: 2,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(2);
 		});
 
 		it("should skip rule with non-object conditions", () => {
@@ -367,6 +365,88 @@ describe("AudienceMatcher", () => {
 				],
 			});
 			expect(matcher.evaluateRules(audience, 1, {})).toBe(2);
+		});
+
+		it("should skip rule when environments is not an array", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						conditions: { value: true },
+						environments: "not-an-array",
+						variant: 1,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(null);
+		});
+
+		it("should not match when environments list contains fractional IDs", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						conditions: { value: true },
+						environments: [1.5],
+						variant: 1,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(null);
+			expect(matcher.evaluateRules(audience, 2, {})).toBe(null);
+		});
+
+		it("should skip environment-scoped rule when environmentId is 0 and not in list", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						conditions: { value: true },
+						environments: [1, 2],
+						variant: 1,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 0, {})).toBe(null);
+		});
+
+		it("should skip rule when conditions evaluation throws and continue to next rule", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "throws",
+						type: "assign",
+						conditions: { badOperator: [1, 2] },
+						environments: [],
+						variant: 1,
+					},
+					{
+						name: "fallback",
+						type: "assign",
+						environments: [],
+						variant: 2,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(2);
+		});
+
+		it("should return negative variant (bounds checking is caller responsibility)", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						conditions: null,
+						environments: [],
+						variant: -1,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(-1);
 		});
 	});
 });

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -41,7 +41,8 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [],
 						variant: 1,
 					},
@@ -55,7 +56,8 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [],
 						variant: 1,
 					},
@@ -69,7 +71,8 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [2],
 						variant: 1,
 					},
@@ -83,7 +86,8 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [1, 2],
 						variant: 2,
 					},
@@ -98,7 +102,8 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ value: true }],
+						type: "assign",
+						conditions: { value: true },
 						environments: [],
 						variant: 1,
 					},
@@ -114,7 +119,8 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ value: true }],
+						type: "assign",
+						conditions: { value: true },
 						environments: [1],
 						variant: 1,
 					},
@@ -128,13 +134,15 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [],
 						variant: 1,
 					},
 					{
 						name: "rule2",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [],
 						variant: 2,
 					},
@@ -143,12 +151,13 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(1);
 		});
 
-		it("should return variant when conditions are empty (matches all)", () => {
+		it("should return variant when conditions is null (matches all)", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
 						name: "rule1",
-						and: [],
+						type: "assign",
+						conditions: null,
 						environments: [],
 						variant: 3,
 					},
@@ -157,11 +166,12 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules(audience, 1, {})).toBe(3);
 		});
 
-		it("should return variant when and field is absent (matches all)", () => {
+		it("should return variant when conditions field is absent (matches all)", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
 						name: "rule1",
+						type: "assign",
 						environments: [],
 						variant: 3,
 					},
@@ -180,7 +190,7 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [],
+						type: "assign",
 						environments: [],
 					},
 				],
@@ -193,7 +203,7 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [],
+						type: "assign",
 						environments: [],
 						variant: "bad",
 					},
@@ -207,13 +217,13 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "bad rule",
-						and: [],
+						type: "assign",
 						environments: [],
 						variant: "not a number",
 					},
 					{
 						name: "good rule",
-						and: [],
+						type: "assign",
 						environments: [],
 						variant: 2,
 					},
@@ -227,12 +237,12 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "no variant",
-						and: [],
+						type: "assign",
 						environments: [],
 					},
 					{
 						name: "good rule",
-						and: [],
+						type: "assign",
 						environments: [],
 						variant: 1,
 					},
@@ -246,18 +256,53 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules('{"rules":[null]}', 1, {})).toBe(null);
 		});
 
-		it("should skip to second rule when first does not match", () => {
+		it("should skip rules with non-assign type", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+						type: "other",
 						environments: [],
 						variant: 1,
 					},
 					{
 						name: "rule2",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						environments: [],
+						variant: 2,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(2);
+		});
+
+		it("should skip rules with missing type", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						environments: [],
+						variant: 1,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(null);
+		});
+
+		it("should skip to second rule when first does not match", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
+						environments: [],
+						variant: 1,
+					},
+					{
+						name: "rule2",
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [],
 						variant: 2,
 					},
@@ -271,13 +316,15 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "GB" }] }] },
 						environments: [],
 						variant: 1,
 					},
 					{
 						name: "rule2",
-						and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+						type: "assign",
+						conditions: { and: [{ eq: [{ var: "country" }, { value: "US" }] }] },
 						environments: [],
 						variant: 2,
 					},
@@ -291,13 +338,35 @@ describe("AudienceMatcher", () => {
 				rules: [
 					{
 						name: "rule1",
-						and: [{ value: true }],
+						type: "assign",
+						conditions: { value: true },
 						environments: [],
 						variant: 0,
 					},
 				],
 			});
 			expect(matcher.evaluateRules(audience, 1, {})).toBe(0);
+		});
+
+		it("should skip rule with non-object conditions", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						name: "rule1",
+						type: "assign",
+						conditions: "invalid",
+						environments: [],
+						variant: 1,
+					},
+					{
+						name: "rule2",
+						type: "assign",
+						environments: [],
+						variant: 2,
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(2);
 		});
 	});
 });

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -28,12 +28,12 @@ describe("AudienceMatcher", () => {
 	});
 	describe("evaluateRules", () => {
 		it("should return null when no rules in audience", () => {
-			expect(matcher.evaluateRules("{}", "production", {})).toBe(null);
-			expect(matcher.evaluateRules('{"filter":[]}', "production", {})).toBe(null);
+			expect(matcher.evaluateRules("{}", 1, {})).toBe(null);
+			expect(matcher.evaluateRules('{"filter":[]}', 1, {})).toBe(null);
 		});
 
 		it("should return null when rules is empty array", () => {
-			expect(matcher.evaluateRules('{"rules":[]}', "production", {})).toBe(null);
+			expect(matcher.evaluateRules('{"rules":[]}', 1, {})).toBe(null);
 		});
 
 		it("should return variant when conditions match", () => {
@@ -51,7 +51,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(1);
+			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(1);
 		});
 
 		it("should return null when conditions do not match", () => {
@@ -69,10 +69,10 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "GB" })).toBe(null);
+			expect(matcher.evaluateRules(audience, 1, { country: "GB" })).toBe(null);
 		});
 
-		it("should skip rules with non-matching environments", () => {
+		it("should skip rules with non-matching environment ids", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
@@ -80,17 +80,17 @@ describe("AudienceMatcher", () => {
 							{
 								name: "rule1",
 								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: ["staging"],
+								environments: [2],
 								variant: 1,
 							},
 						],
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(null);
+			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(null);
 		});
 
-		it("should match when environment is in the environments list", () => {
+		it("should match when environment id is in the environments list", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
@@ -98,15 +98,15 @@ describe("AudienceMatcher", () => {
 							{
 								name: "rule1",
 								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
-								environments: ["production", "staging"],
+								environments: [1, 2],
 								variant: 2,
 							},
 						],
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
-			expect(matcher.evaluateRules(audience, "staging", { country: "US" })).toBe(2);
+			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(2);
+			expect(matcher.evaluateRules(audience, 2, { country: "US" })).toBe(2);
 		});
 
 		it("should match all environments when environments is empty", () => {
@@ -124,12 +124,12 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(1);
-			expect(matcher.evaluateRules(audience, "staging", {})).toBe(1);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(1);
+			expect(matcher.evaluateRules(audience, 2, {})).toBe(1);
 			expect(matcher.evaluateRules(audience, null, {})).toBe(1);
 		});
 
-		it("should skip rules when environments is non-empty and environmentName is null", () => {
+		it("should skip rules when environments is non-empty and environmentId is null", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{
@@ -137,7 +137,7 @@ describe("AudienceMatcher", () => {
 							{
 								name: "rule1",
 								and: [{ value: true }],
-								environments: ["production"],
+								environments: [1],
 								variant: 1,
 							},
 						],
@@ -168,7 +168,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(1);
+			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(1);
 		});
 
 		it("should return variant when conditions are empty (matches all)", () => {
@@ -186,7 +186,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(3);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(3);
 		});
 
 		it("should return variant when and field is absent (matches all)", () => {
@@ -203,12 +203,12 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(3);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(3);
 		});
 
 		it("should handle malformed audience JSON gracefully", () => {
-			expect(matcher.evaluateRules("not json", "production", {})).toBe(null);
-			expect(matcher.evaluateRules("", "production", {})).toBe(null);
+			expect(matcher.evaluateRules("not json", 1, {})).toBe(null);
+			expect(matcher.evaluateRules("", 1, {})).toBe(null);
 		});
 
 		it("should return null when rule has no variant property", () => {
@@ -225,7 +225,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(null);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(null);
 		});
 
 		it("should return null when variant is not a number", () => {
@@ -243,7 +243,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(null);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(null);
 		});
 
 		it("should skip rule with invalid variant and continue to next valid rule", () => {
@@ -267,7 +267,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(2);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(2);
 		});
 
 		it("should skip rule with missing variant and continue to next valid rule", () => {
@@ -290,13 +290,13 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(1);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(1);
 		});
 
 		it("should handle malformed rules gracefully", () => {
-			expect(matcher.evaluateRules('{"rules":"not an array"}', "production", {})).toBe(null);
-			expect(matcher.evaluateRules('{"rules":[{"or":"not an array"}]}', "production", {})).toBe(null);
-			expect(matcher.evaluateRules('{"rules":[null]}', "production", {})).toBe(null);
+			expect(matcher.evaluateRules('{"rules":"not an array"}', 1, {})).toBe(null);
+			expect(matcher.evaluateRules('{"rules":[{"or":"not an array"}]}', 1, {})).toBe(null);
+			expect(matcher.evaluateRules('{"rules":[null]}', 1, {})).toBe(null);
 		});
 
 		it("should skip to second rule when first does not match", () => {
@@ -320,7 +320,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
+			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(2);
 		});
 
 		it("should evaluate second rule group when first has no match", () => {
@@ -348,7 +348,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
+			expect(matcher.evaluateRules(audience, 1, { country: "US" })).toBe(2);
 		});
 
 		it("should support variant 0", () => {
@@ -366,7 +366,7 @@ describe("AudienceMatcher", () => {
 					},
 				],
 			});
-			expect(matcher.evaluateRules(audience, "production", {})).toBe(0);
+			expect(matcher.evaluateRules(audience, 1, {})).toBe(0);
 		});
 	});
 });

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -276,6 +276,34 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
 		});
 
+		it("should evaluate second rule group when first has no match", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+								environments: [],
+								variant: 1,
+							},
+						],
+					},
+					{
+						or: [
+							{
+								name: "rule2",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: [],
+								variant: 2,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
+		});
+
 		it("should support variant 0", () => {
 			const audience = JSON.stringify({
 				rules: [

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -26,6 +26,239 @@ describe("AudienceMatcher", () => {
 		expect(matcher.evaluate('{"filter":[{"not":{"var":"returning"}}]}', { returning: true })).toBe(false);
 		expect(matcher.evaluate('{"filter":[{"not":{"var":"returning"}}]}', { returning: false })).toBe(true);
 	});
+	describe("evaluateRules", () => {
+		it("should return null when no rules in audience", () => {
+			expect(matcher.evaluateRules("{}", "production", {})).toBe(null);
+			expect(matcher.evaluateRules('{"filter":[]}', "production", {})).toBe(null);
+		});
+
+		it("should return null when rules is empty array", () => {
+			expect(matcher.evaluateRules('{"rules":[]}', "production", {})).toBe(null);
+		});
+
+		it("should return variant when conditions match", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: [],
+								variant: 1,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(1);
+		});
+
+		it("should return null when conditions do not match", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: [],
+								variant: 1,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "GB" })).toBe(null);
+		});
+
+		it("should skip rules with non-matching environments", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: ["staging"],
+								variant: 1,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(null);
+		});
+
+		it("should match when environment is in the environments list", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: ["production", "staging"],
+								variant: 2,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
+			expect(matcher.evaluateRules(audience, "staging", { country: "US" })).toBe(2);
+		});
+
+		it("should match all environments when environments is empty", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ value: true }],
+								environments: [],
+								variant: 1,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(1);
+			expect(matcher.evaluateRules(audience, "staging", {})).toBe(1);
+			expect(matcher.evaluateRules(audience, null, {})).toBe(1);
+		});
+
+		it("should skip rules when environments is non-empty and environmentName is null", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ value: true }],
+								environments: ["production"],
+								variant: 1,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, null, {})).toBe(null);
+		});
+
+		it("should return first matching rule (first match wins)", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: [],
+								variant: 1,
+							},
+							{
+								name: "rule2",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: [],
+								variant: 2,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(1);
+		});
+
+		it("should return variant when conditions are empty (matches all)", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [],
+								environments: [],
+								variant: 3,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(3);
+		});
+
+		it("should return variant when and field is absent (matches all)", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								environments: [],
+								variant: 3,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(3);
+		});
+
+		it("should handle malformed audience JSON gracefully", () => {
+			expect(matcher.evaluateRules("not json", "production", {})).toBe(null);
+			expect(matcher.evaluateRules("", "production", {})).toBe(null);
+		});
+
+		it("should handle malformed rules gracefully", () => {
+			expect(matcher.evaluateRules('{"rules":"not an array"}', "production", {})).toBe(null);
+			expect(matcher.evaluateRules('{"rules":[{"or":"not an array"}]}', "production", {})).toBe(null);
+			expect(matcher.evaluateRules('{"rules":[null]}', "production", {})).toBe(null);
+		});
+
+		it("should skip to second rule when first does not match", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ eq: [{ var: "country" }, { value: "GB" }] }],
+								environments: [],
+								variant: 1,
+							},
+							{
+								name: "rule2",
+								and: [{ eq: [{ var: "country" }, { value: "US" }] }],
+								environments: [],
+								variant: 2,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", { country: "US" })).toBe(2);
+		});
+
+		it("should support variant 0", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [{ value: true }],
+								environments: [],
+								variant: 0,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(0);
+		});
+	});
 });
 
 /*

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -382,7 +382,7 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules(audience, 1, {})).toBe(null);
 		});
 
-		it("should not match when environments list contains fractional IDs", () => {
+		it("should not match integer environmentIds against fractional entries in environments list", () => {
 			const audience = JSON.stringify({
 				rules: [
 					{

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -246,6 +246,53 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules(audience, "production", {})).toBe(null);
 		});
 
+		it("should skip rule with invalid variant and continue to next valid rule", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "bad rule",
+								and: [],
+								environments: [],
+								variant: "not a number",
+							},
+							{
+								name: "good rule",
+								and: [],
+								environments: [],
+								variant: 2,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(2);
+		});
+
+		it("should skip rule with missing variant and continue to next valid rule", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "no variant",
+								and: [],
+								environments: [],
+							},
+							{
+								name: "good rule",
+								and: [],
+								environments: [],
+								variant: 1,
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(1);
+		});
+
 		it("should handle malformed rules gracefully", () => {
 			expect(matcher.evaluateRules('{"rules":"not an array"}', "production", {})).toBe(null);
 			expect(matcher.evaluateRules('{"rules":[{"or":"not an array"}]}', "production", {})).toBe(null);

--- a/src/__tests__/matcher.test.js
+++ b/src/__tests__/matcher.test.js
@@ -211,6 +211,41 @@ describe("AudienceMatcher", () => {
 			expect(matcher.evaluateRules("", "production", {})).toBe(null);
 		});
 
+		it("should return null when rule has no variant property", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [],
+								environments: [],
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(null);
+		});
+
+		it("should return null when variant is not a number", () => {
+			const audience = JSON.stringify({
+				rules: [
+					{
+						or: [
+							{
+								name: "rule1",
+								and: [],
+								environments: [],
+								variant: "bad",
+							},
+						],
+					},
+				],
+			});
+			expect(matcher.evaluateRules(audience, "production", {})).toBe(null);
+		});
+
 		it("should handle malformed rules gracefully", () => {
 			expect(matcher.evaluateRules('{"rules":"not an array"}', "production", {})).toBe(null);
 			expect(matcher.evaluateRules('{"rules":[{"or":"not an array"}]}', "production", {})).toBe(null);

--- a/src/client.ts
+++ b/src/client.ts
@@ -302,10 +302,6 @@ export default class Client {
 		return this._opts.application;
 	}
 
-	getEnvironment(): string {
-		return this._opts.environment;
-	}
-
 	getUnauthed(options: ClientRequestOptions) {
 		return this.request({
 			...options,

--- a/src/client.ts
+++ b/src/client.ts
@@ -85,6 +85,10 @@ export default class Client {
 		this._delay = 50;
 	}
 
+	getEnvironment(): string {
+		return this._opts.environment;
+	}
+
 	getContext(options?: Partial<ClientRequestOptions>) {
 		return this.getUnauthed({
 			...options,

--- a/src/context.ts
+++ b/src/context.ts
@@ -61,6 +61,7 @@ type Assignment = {
 	fullOn: boolean;
 	custom: boolean;
 	audienceMismatch: boolean;
+	ruleVariant?: number | null;
 	trafficSplit?: number[];
 	variables?: Record<string, unknown>;
 	attrsSeq?: number;
@@ -466,10 +467,20 @@ export default class Context {
 		const audienceMatches = (experiment: ExperimentData, assignment: Assignment) => {
 			if (experiment.audience && experiment.audience.length > 0) {
 				if (this._attrsSeq > (assignment.attrsSeq ?? 0)) {
-					const result = this._audienceMatcher.evaluate(experiment.audience, this._getAttributesMap());
+					const attrs = this._getAttributesMap();
+					const result = this._audienceMatcher.evaluate(experiment.audience, attrs);
 					const newAudienceMismatch = typeof result === "boolean" ? !result : false;
 
 					if (newAudienceMismatch !== assignment.audienceMismatch) {
+						return false;
+					}
+
+					const ruleVariant = this._audienceMatcher.evaluateRules(
+						experiment.audience,
+						this._environmentName,
+						attrs
+					);
+					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
 
@@ -548,6 +559,8 @@ export default class Context {
 								this._getAttributesMap()
 						  )
 						: null;
+
+				assignment.ruleVariant = ruleVariant;
 
 				if (ruleVariant !== null) {
 					assignment.assigned = true;

--- a/src/context.ts
+++ b/src/context.ts
@@ -61,6 +61,7 @@ type Assignment = {
 	fullOn: boolean;
 	custom: boolean;
 	audienceMismatch: boolean;
+	targetingRule: boolean;
 	ruleVariant?: number | null;
 	trafficSplit?: number[];
 	variables?: Record<string, unknown>;
@@ -89,6 +90,7 @@ export type Exposure = {
 	fullOn: boolean;
 	custom: boolean;
 	audienceMismatch: boolean;
+	targetingRule: boolean;
 };
 
 export type Attribute = {
@@ -524,6 +526,7 @@ export default class Context {
 			fullOn: false,
 			custom: false,
 			audienceMismatch: false,
+			targetingRule: false,
 		};
 
 		this._assignments[experimentName] = assignment;
@@ -556,13 +559,11 @@ export default class Context {
 				assignment.ruleVariant = ruleVariant;
 
 				if (ruleVariant !== null) {
-					// Rule-matched: assigned=true + overridden=true
-					// SDK overrides: assigned=false + overridden=true
-					// This distinction lets analytics differentiate the two cases
 					assignment.assigned = true;
 					assignment.eligible = true;
 					assignment.variant = ruleVariant;
 					assignment.overridden = true;
+					assignment.targetingRule = true;
 				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {
 					assignment.variant = 0;
 				} else if (experiment.data.fullOnVariant === 0) {
@@ -654,6 +655,7 @@ export default class Context {
 			fullOn: assignment.fullOn,
 			custom: assignment.custom,
 			audienceMismatch: assignment.audienceMismatch,
+			targetingRule: assignment.targetingRule,
 		};
 		this._logEvent("exposure", exposureEvent);
 
@@ -881,6 +883,7 @@ export default class Context {
 							fullOn: x.fullOn,
 							custom: x.custom,
 							audienceMismatch: x.audienceMismatch,
+							targetingRule: x.targetingRule,
 						}));
 					}
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -170,7 +170,7 @@ export default class Context {
 		this._units = {};
 		this._assigners = {};
 		this._audienceMatcher = new AudienceMatcher();
-		this._environmentName = sdk.getClient()?.getEnvironment() ?? null;
+		this._environmentName = sdk.getClient().getEnvironment();
 		this._attrsSeq = 0;
 
 		if (params.units) {
@@ -563,6 +563,9 @@ export default class Context {
 				assignment.ruleVariant = ruleVariant;
 
 				if (ruleVariant !== null) {
+					// Rule-matched: assigned=true + overridden=true
+					// SDK overrides: assigned=false + overridden=true
+					// This distinction lets analytics differentiate the two cases
 					assignment.assigned = true;
 					assignment.eligible = true;
 					assignment.variant = ruleVariant;

--- a/src/context.ts
+++ b/src/context.ts
@@ -497,7 +497,10 @@ export default class Context {
 				}
 
 				if (experiment.assignmentRules && experiment.assignmentRules.length > 0) {
-					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.assignmentRules, this._environmentId, attrs);
+					const rawRuleVariant = this._audienceMatcher.evaluateRules(experiment.assignmentRules, this._environmentId, attrs);
+					const ruleVariant = rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < experiment.variants.length
+						? rawRuleVariant
+						: null;
 					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
@@ -577,7 +580,10 @@ export default class Context {
 				}
 
 				if (experiment.data.assignmentRules && experiment.data.assignmentRules.length > 0) {
-					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.assignmentRules, this._environmentId, attrs);
+					const rawRuleVariant = this._audienceMatcher.evaluateRules(experiment.data.assignmentRules, this._environmentId, attrs);
+					ruleVariant = rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < experiment.data.variants.length
+						? rawRuleVariant
+						: null;
 				}
 
 				assignment.ruleVariant = ruleVariant;

--- a/src/context.ts
+++ b/src/context.ts
@@ -61,7 +61,7 @@ type Assignment = {
 	fullOn: boolean;
 	custom: boolean;
 	audienceMismatch: boolean;
-	targetingRule: boolean;
+	ruleOverride: boolean;
 	ruleVariant?: number | null;
 	trafficSplit?: number[];
 	variables?: Record<string, unknown>;
@@ -90,7 +90,7 @@ export type Exposure = {
 	fullOn: boolean;
 	custom: boolean;
 	audienceMismatch: boolean;
-	targetingRule: boolean;
+	ruleOverride: boolean;
 };
 
 export type Attribute = {
@@ -526,7 +526,7 @@ export default class Context {
 			fullOn: false,
 			custom: false,
 			audienceMismatch: false,
-			targetingRule: false,
+			ruleOverride: false,
 		};
 
 		this._assignments[experimentName] = assignment;
@@ -563,7 +563,7 @@ export default class Context {
 					assignment.eligible = true;
 					assignment.variant = ruleVariant;
 					assignment.overridden = true;
-					assignment.targetingRule = true;
+					assignment.ruleOverride = true;
 				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {
 					assignment.variant = 0;
 				} else if (experiment.data.fullOnVariant === 0) {
@@ -655,7 +655,7 @@ export default class Context {
 			fullOn: assignment.fullOn,
 			custom: assignment.custom,
 			audienceMismatch: assignment.audienceMismatch,
-			targetingRule: assignment.targetingRule,
+			ruleOverride: assignment.ruleOverride,
 		};
 		this._logEvent("exposure", exposureEvent);
 
@@ -883,7 +883,7 @@ export default class Context {
 							fullOn: x.fullOn,
 							custom: x.custom,
 							audienceMismatch: x.audienceMismatch,
-							targetingRule: x.targetingRule,
+							ruleOverride: x.ruleOverride,
 						}));
 					}
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -497,7 +497,7 @@ export default class Context {
 		if (experimentName in this._assignments) {
 			const assignment = this._assignments[experimentName];
 			if (hasOverride) {
-				if (assignment.overridden && assignment.variant === this._overrides[experimentName]) {
+				if (assignment.overridden && !assignment.assigned && assignment.variant === this._overrides[experimentName]) {
 					// override up-to-date
 					return assignment;
 				}

--- a/src/context.ts
+++ b/src/context.ts
@@ -124,6 +124,7 @@ export type ContextOptions = {
 
 export type ContextData = {
 	experiments?: ExperimentData[];
+	environment_id?: number;
 };
 
 export default class Context {
@@ -132,7 +133,7 @@ export default class Context {
 	private readonly _audienceMatcher: AudienceMatcher;
 	private readonly _cassignments: Record<string, number>;
 	private readonly _dataProvider: ContextDataProvider;
-	private readonly _environmentName: string | null;
+	private _environmentId: number | null;
 	private readonly _eventLogger: EventLogger;
 	private readonly _opts: ContextOptions;
 	private readonly _publisher: ContextPublisher;
@@ -172,7 +173,7 @@ export default class Context {
 		this._units = {};
 		this._assigners = {};
 		this._audienceMatcher = new AudienceMatcher();
-		this._environmentName = sdk.getClient().getEnvironment();
+		this._environmentId = null;
 		this._attrsSeq = 0;
 
 		if (params.units) {
@@ -477,7 +478,7 @@ export default class Context {
 						return false;
 					}
 
-					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.audience, this._environmentName, attrs);
+					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.audience, this._environmentId, attrs);
 					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
@@ -553,7 +554,7 @@ export default class Context {
 						assignment.audienceMismatch = !result;
 					}
 
-					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.audience, this._environmentName, attrs);
+					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.audience, this._environmentId, attrs);
 				}
 
 				assignment.ruleVariant = ruleVariant;
@@ -979,6 +980,7 @@ export default class Context {
 
 	private _init(data: ContextData, assignments: Record<string, Assignment> = {}) {
 		this._data = data;
+		this._environmentId = data.environment_id ?? null;
 
 		const index: Record<string, Experiment> = {};
 		const indexVariables: Record<string, Experiment[]> = {};

--- a/src/context.ts
+++ b/src/context.ts
@@ -440,6 +440,13 @@ export default class Context {
 		}
 	}
 
+	private _computeRuleVariant(assignmentRules: string, variantCount: number, attrs: Record<string, unknown>): number | null {
+		const rawRuleVariant = this._audienceMatcher.evaluateRules(assignmentRules, this._environmentId, attrs);
+		return rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < variantCount
+			? rawRuleVariant
+			: null;
+	}
+
 	private _checkReady(expectNotFinalized?: boolean) {
 		if (!this.isReady()) {
 			throw new Error("ABSmartly Context is not yet ready.");
@@ -497,10 +504,7 @@ export default class Context {
 				}
 
 				if (experiment.assignmentRules && experiment.assignmentRules.length > 0) {
-					const rawRuleVariant = this._audienceMatcher.evaluateRules(experiment.assignmentRules, this._environmentId, attrs);
-					const ruleVariant = rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < experiment.variants.length
-						? rawRuleVariant
-						: null;
+					const ruleVariant = this._computeRuleVariant(experiment.assignmentRules, experiment.variants.length, attrs);
 					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
@@ -580,10 +584,7 @@ export default class Context {
 				}
 
 				if (experiment.data.assignmentRules && experiment.data.assignmentRules.length > 0) {
-					const rawRuleVariant = this._audienceMatcher.evaluateRules(experiment.data.assignmentRules, this._environmentId, attrs);
-					ruleVariant = rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < experiment.data.variants.length
-						? rawRuleVariant
-						: null;
+					ruleVariant = this._computeRuleVariant(experiment.data.assignmentRules, experiment.data.variants.length, attrs);
 				}
 
 				assignment.ruleVariant = ruleVariant;

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,7 +31,7 @@ export type ExperimentData = {
 	trafficSeedHi: number;
 	trafficSeedLo: number;
 	audience: string;
-	assignmentRules: string;
+	assignmentRules?: string;
 	audienceStrict: boolean;
 	split: number[];
 	seedHi: number;
@@ -64,6 +64,7 @@ type Assignment = {
 	audienceMismatch: boolean;
 	ruleOverride: boolean;
 	ruleVariant?: number | null;
+	ruleKey?: string;
 	trafficSplit?: number[];
 	variables?: Record<string, unknown>;
 	attrsSeq?: number;
@@ -469,7 +470,21 @@ export default class Context {
 		};
 
 		const audienceMatches = (experiment: ExperimentData, assignment: Assignment) => {
-			if (this._attrsSeq > (assignment.attrsSeq ?? 0)) {
+			const ruleKey = experiment.assignmentRules
+				? `${experiment.assignmentRules}:${this._environmentId}`
+				: "";
+			const ruleKeyChanged = ruleKey !== (assignment.ruleKey ?? "");
+
+			if (ruleKeyChanged) {
+				if (!ruleKey && (assignment.ruleVariant != null || assignment.ruleOverride)) {
+					assignment.ruleVariant = undefined;
+					assignment.ruleOverride = false;
+					assignment.ruleKey = undefined;
+					return false;
+				}
+			}
+
+			if (this._attrsSeq > (assignment.attrsSeq ?? 0) || ruleKeyChanged) {
 				const attrs = this._getAttributesMap();
 
 				if (experiment.audience && experiment.audience.length > 0) {
@@ -490,6 +505,7 @@ export default class Context {
 					assignment.ruleVariant = ruleVariant;
 				}
 
+				assignment.ruleKey = ruleKey;
 				assignment.attrsSeq = this._attrsSeq;
 			}
 			return true;
@@ -565,6 +581,9 @@ export default class Context {
 				}
 
 				assignment.ruleVariant = ruleVariant;
+				assignment.ruleKey = experiment.data.assignmentRules
+					? `${experiment.data.assignmentRules}:${this._environmentId}`
+					: "";
 
 				if (ruleVariant !== null && ruleVariant >= 0 && ruleVariant < experiment.data.variants.length) {
 					assignment.variant = ruleVariant;

--- a/src/context.ts
+++ b/src/context.ts
@@ -543,22 +543,22 @@ export default class Context {
 			if (experiment != null) {
 				const unitType = experiment.data.unitType;
 
+				let ruleVariant: number | null = null;
+
 				if (experiment.data.audience && experiment.data.audience.length > 0) {
-					const result = this._audienceMatcher.evaluate(experiment.data.audience, this._getAttributesMap());
+					const attrs = this._getAttributesMap();
+					const result = this._audienceMatcher.evaluate(experiment.data.audience, attrs);
 
 					if (typeof result === "boolean") {
 						assignment.audienceMismatch = !result;
 					}
-				}
 
-				const ruleVariant =
-					experiment.data.audience && experiment.data.audience.length > 0
-						? this._audienceMatcher.evaluateRules(
-								experiment.data.audience,
-								this._environmentName,
-								this._getAttributesMap()
-						  )
-						: null;
+					ruleVariant = this._audienceMatcher.evaluateRules(
+						experiment.data.audience,
+						this._environmentName,
+						attrs
+					);
+				}
 
 				assignment.ruleVariant = ruleVariant;
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -129,6 +129,7 @@ export default class Context {
 	private readonly _audienceMatcher: AudienceMatcher;
 	private readonly _cassignments: Record<string, number>;
 	private readonly _dataProvider: ContextDataProvider;
+	private readonly _environmentName: string | null;
 	private readonly _eventLogger: EventLogger;
 	private readonly _opts: ContextOptions;
 	private readonly _publisher: ContextPublisher;
@@ -168,6 +169,7 @@ export default class Context {
 		this._units = {};
 		this._assigners = {};
 		this._audienceMatcher = new AudienceMatcher();
+		this._environmentName = sdk.getClient()?.getEnvironment() ?? null;
 		this._attrsSeq = 0;
 
 		if (params.units) {
@@ -538,7 +540,20 @@ export default class Context {
 					}
 				}
 
-				if (experiment.data.audienceStrict && assignment.audienceMismatch) {
+				const ruleVariant =
+					experiment.data.audience && experiment.data.audience.length > 0
+						? this._audienceMatcher.evaluateRules(
+								experiment.data.audience,
+								this._environmentName,
+								this._getAttributesMap()
+						  )
+						: null;
+
+				if (ruleVariant !== null) {
+					assignment.assigned = true;
+					assignment.variant = ruleVariant;
+					assignment.custom = true;
+				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {
 					assignment.variant = 0;
 				} else if (experiment.data.fullOnVariant === 0) {
 					if (unitType !== null) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,7 +31,7 @@ export type ExperimentData = {
 	trafficSeedHi: number;
 	trafficSeedLo: number;
 	audience: string;
-	assignment_rules: string;
+	assignmentRules: string;
 	audienceStrict: boolean;
 	split: number[];
 	seedHi: number;
@@ -481,8 +481,8 @@ export default class Context {
 					}
 				}
 
-				if (experiment.assignment_rules && experiment.assignment_rules.length > 0) {
-					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.assignment_rules, this._environmentId, attrs);
+				if (experiment.assignmentRules && experiment.assignmentRules.length > 0) {
+					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.assignmentRules, this._environmentId, attrs);
 					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
@@ -560,13 +560,13 @@ export default class Context {
 					}
 				}
 
-				if (experiment.data.assignment_rules && experiment.data.assignment_rules.length > 0) {
-					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.assignment_rules, this._environmentId, attrs);
+				if (experiment.data.assignmentRules && experiment.data.assignmentRules.length > 0) {
+					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.assignmentRules, this._environmentId, attrs);
 				}
 
 				assignment.ruleVariant = ruleVariant;
 
-				if (ruleVariant !== null) {
+				if (ruleVariant !== null && ruleVariant >= 0 && ruleVariant < experiment.data.variants.length) {
 					assignment.variant = ruleVariant;
 					assignment.ruleOverride = true;
 				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -475,15 +475,12 @@ export default class Context {
 						return false;
 					}
 
-					const ruleVariant = this._audienceMatcher.evaluateRules(
-						experiment.audience,
-						this._environmentName,
-						attrs
-					);
+					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.audience, this._environmentName, attrs);
 					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
 
+					assignment.ruleVariant = ruleVariant;
 					assignment.attrsSeq = this._attrsSeq;
 				}
 			}
@@ -553,11 +550,7 @@ export default class Context {
 						assignment.audienceMismatch = !result;
 					}
 
-					ruleVariant = this._audienceMatcher.evaluateRules(
-						experiment.data.audience,
-						this._environmentName,
-						attrs
-					);
+					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.audience, this._environmentName, attrs);
 				}
 
 				assignment.ruleVariant = ruleVariant;

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,6 +31,7 @@ export type ExperimentData = {
 	trafficSeedHi: number;
 	trafficSeedLo: number;
 	audience: string;
+	assignment_rules: string;
 	audienceStrict: boolean;
 	split: number[];
 	seedHi: number;
@@ -468,24 +469,28 @@ export default class Context {
 		};
 
 		const audienceMatches = (experiment: ExperimentData, assignment: Assignment) => {
-			if (experiment.audience && experiment.audience.length > 0) {
-				if (this._attrsSeq > (assignment.attrsSeq ?? 0)) {
-					const attrs = this._getAttributesMap();
+			if (this._attrsSeq > (assignment.attrsSeq ?? 0)) {
+				const attrs = this._getAttributesMap();
+
+				if (experiment.audience && experiment.audience.length > 0) {
 					const result = this._audienceMatcher.evaluate(experiment.audience, attrs);
 					const newAudienceMismatch = typeof result === "boolean" ? !result : false;
 
 					if (newAudienceMismatch !== assignment.audienceMismatch) {
 						return false;
 					}
+				}
 
-					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.audience, this._environmentId, attrs);
+				if (experiment.assignment_rules && experiment.assignment_rules.length > 0) {
+					const ruleVariant = this._audienceMatcher.evaluateRules(experiment.assignment_rules, this._environmentId, attrs);
 					if (ruleVariant !== (assignment.ruleVariant ?? null)) {
 						return false;
 					}
 
 					assignment.ruleVariant = ruleVariant;
-					assignment.attrsSeq = this._attrsSeq;
 				}
+
+				assignment.attrsSeq = this._attrsSeq;
 			}
 			return true;
 		};
@@ -545,16 +550,18 @@ export default class Context {
 				const unitType = experiment.data.unitType;
 
 				let ruleVariant: number | null = null;
+				const attrs = this._getAttributesMap();
 
 				if (experiment.data.audience && experiment.data.audience.length > 0) {
-					const attrs = this._getAttributesMap();
 					const result = this._audienceMatcher.evaluate(experiment.data.audience, attrs);
 
 					if (typeof result === "boolean") {
 						assignment.audienceMismatch = !result;
 					}
+				}
 
-					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.audience, this._environmentId, attrs);
+				if (experiment.data.assignment_rules && experiment.data.assignment_rules.length > 0) {
+					ruleVariant = this._audienceMatcher.evaluateRules(experiment.data.assignment_rules, this._environmentId, attrs);
 				}
 
 				assignment.ruleVariant = ruleVariant;

--- a/src/context.ts
+++ b/src/context.ts
@@ -551,6 +551,7 @@ export default class Context {
 
 				if (ruleVariant !== null) {
 					assignment.assigned = true;
+					assignment.eligible = true;
 					assignment.variant = ruleVariant;
 					assignment.overridden = true;
 				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -496,7 +496,7 @@ export default class Context {
 		if (experimentName in this._assignments) {
 			const assignment = this._assignments[experimentName];
 			if (hasOverride) {
-				if (assignment.overridden && !assignment.assigned && assignment.variant === this._overrides[experimentName]) {
+				if (assignment.overridden && assignment.variant === this._overrides[experimentName]) {
 					// override up-to-date
 					return assignment;
 				}
@@ -559,10 +559,7 @@ export default class Context {
 				assignment.ruleVariant = ruleVariant;
 
 				if (ruleVariant !== null) {
-					assignment.assigned = true;
-					assignment.eligible = true;
 					assignment.variant = ruleVariant;
-					assignment.overridden = true;
 					assignment.ruleOverride = true;
 				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {
 					assignment.variant = 0;
@@ -758,7 +755,7 @@ export default class Context {
 					this._queueExposure(experimentName, assignment);
 				}
 
-				if (key in assignment.variables && (assignment.assigned || assignment.overridden)) {
+				if (key in assignment.variables && (assignment.assigned || assignment.overridden || assignment.ruleOverride)) {
 					return assignment.variables[key] as string;
 				}
 			}
@@ -772,7 +769,7 @@ export default class Context {
 			const experimentName = this._indexVariables[key][i].data.name;
 			const assignment = this._assign(experimentName);
 			if (assignment.variables !== undefined) {
-				if (key in assignment.variables && (assignment.assigned || assignment.overridden)) {
+				if (key in assignment.variables && (assignment.assigned || assignment.overridden || assignment.ruleOverride)) {
 					return assignment.variables[key] as string;
 				}
 			}

--- a/src/context.ts
+++ b/src/context.ts
@@ -552,7 +552,7 @@ export default class Context {
 				if (ruleVariant !== null) {
 					assignment.assigned = true;
 					assignment.variant = ruleVariant;
-					assignment.custom = true;
+					assignment.overridden = true;
 				} else if (experiment.data.audienceStrict && assignment.audienceMismatch) {
 					assignment.variant = 0;
 				} else if (experiment.data.fullOnVariant === 0) {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -47,7 +47,7 @@ export class AudienceMatcher {
 				}
 			}
 		} catch (error) {
-			// parse error or evaluation error - fall through to normal assignment
+			console.error(error);
 		}
 		return null;
 	}

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -17,11 +17,7 @@ export class AudienceMatcher {
 		return null;
 	}
 
-	evaluateRules(
-		audienceString: string,
-		environmentName: string | null,
-		vars: Record<string, unknown>
-	): number | null {
+	evaluateRules(audienceString: string, environmentName: string | null, vars: Record<string, unknown>): number | null {
 		try {
 			const audience = JSON.parse(audienceString);
 			if (audience && Array.isArray(audience.rules)) {
@@ -33,14 +29,15 @@ export class AudienceMatcher {
 								continue;
 							}
 						}
+						if (typeof rule.variant !== "number") continue;
 						const conditions = rule.and;
 						if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
-							return typeof rule.variant === "number" ? rule.variant : null;
+							return rule.variant;
 						}
 						if (Array.isArray(conditions)) {
 							const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
 							if (result === true) {
-								return typeof rule.variant === "number" ? rule.variant : null;
+								return rule.variant;
 							}
 						}
 					}

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -18,34 +18,42 @@ export class AudienceMatcher {
 	}
 
 	evaluateRules(audienceString: string, environmentName: string | null, vars: Record<string, unknown>): number | null {
+		let audience;
 		try {
-			const audience = JSON.parse(audienceString);
-			if (audience && Array.isArray(audience.rules)) {
-				for (const ruleGroup of audience.rules) {
-					if (!ruleGroup || !Array.isArray(ruleGroup.or)) continue;
-					for (const rule of ruleGroup.or) {
-						if (Array.isArray(rule.environments) && rule.environments.length > 0) {
-							if (environmentName == null || !rule.environments.includes(environmentName)) {
-								continue;
-							}
-						}
-						if (typeof rule.variant !== "number") continue;
-						const conditions = rule.and;
-						if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
-							return rule.variant;
-						}
-						if (Array.isArray(conditions)) {
-							const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
-							if (result === true) {
-								return rule.variant;
-							}
-						}
-					}
-				}
-			}
+			audience = JSON.parse(audienceString);
 		} catch (error) {
 			console.error(error);
+			return null;
 		}
+
+		if (!audience || !Array.isArray(audience.rules)) return null;
+
+		for (const ruleGroup of audience.rules) {
+			if (!ruleGroup || !Array.isArray(ruleGroup.or)) continue;
+			for (const rule of ruleGroup.or) {
+				if (Array.isArray(rule.environments) && rule.environments.length > 0) {
+					if (environmentName == null || !rule.environments.includes(environmentName)) {
+						continue;
+					}
+				}
+
+				if (typeof rule.variant !== "number") continue;
+
+				const conditions = rule.and;
+
+				if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
+					return rule.variant;
+				}
+
+				if (!Array.isArray(conditions)) continue;
+
+				const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
+				if (result === true) {
+					return rule.variant;
+				}
+			}
+		}
+
 		return null;
 	}
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -33,13 +33,18 @@ export class AudienceMatcher {
 
 			if (rule.type !== "assign") continue;
 
-			if (Array.isArray(rule.environments) && rule.environments.length > 0) {
-				if (environmentId == null || !rule.environments.includes(environmentId)) {
-					continue;
+			if (rule.environments != null) {
+				if (!Array.isArray(rule.environments)) continue;
+
+				if (rule.environments.length > 0) {
+					if (environmentId == null || !rule.environments.includes(environmentId)) {
+						continue;
+					}
 				}
 			}
 
 			if (typeof rule.variant !== "number") continue;
+			if (rule.variant !== Math.floor(rule.variant)) continue;
 
 			const conditions = rule.conditions;
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -17,7 +17,7 @@ export class AudienceMatcher {
 		return null;
 	}
 
-	evaluateRules(audienceString: string, environmentName: string | null, vars: Record<string, unknown>): number | null {
+	evaluateRules(audienceString: string, environmentId: number | null, vars: Record<string, unknown>): number | null {
 		let audience;
 		try {
 			audience = JSON.parse(audienceString);
@@ -32,7 +32,7 @@ export class AudienceMatcher {
 			if (!ruleGroup || !Array.isArray(ruleGroup.or)) continue;
 			for (const rule of ruleGroup.or) {
 				if (Array.isArray(rule.environments) && rule.environments.length > 0) {
-					if (environmentName == null || !rule.environments.includes(environmentName)) {
+					if (environmentId == null || !rule.environments.includes(environmentId)) {
 						continue;
 					}
 				}

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -17,18 +17,18 @@ export class AudienceMatcher {
 		return null;
 	}
 
-	evaluateRules(audienceString: string, environmentId: number | null, vars: Record<string, unknown>): number | null {
-		let audience;
+	evaluateRules(assignmentRulesString: string, environmentId: number | null, vars: Record<string, unknown>): number | null {
+		let assignmentRules;
 		try {
-			audience = JSON.parse(audienceString);
+			assignmentRules = JSON.parse(assignmentRulesString);
 		} catch (error) {
 			console.error(error);
 			return null;
 		}
 
-		if (!audience || !Array.isArray(audience.rules)) return null;
+		if (!assignmentRules || !Array.isArray(assignmentRules.rules)) return null;
 
-		for (const ruleGroup of audience.rules) {
+		for (const ruleGroup of assignmentRules.rules) {
 			if (!ruleGroup || !Array.isArray(ruleGroup.or)) continue;
 			for (const rule of ruleGroup.or) {
 				if (Array.isArray(rule.environments) && rule.environments.length > 0) {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -31,6 +31,8 @@ export class AudienceMatcher {
 		for (const rule of assignmentRules.rules) {
 			if (!rule) continue;
 
+			if (rule.type !== "assign") continue;
+
 			if (Array.isArray(rule.environments) && rule.environments.length > 0) {
 				if (environmentId == null || !rule.environments.includes(environmentId)) {
 					continue;
@@ -39,17 +41,21 @@ export class AudienceMatcher {
 
 			if (typeof rule.variant !== "number") continue;
 
-			const conditions = rule.and;
+			const conditions = rule.conditions;
 
-			if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
+			if (conditions == null) {
 				return rule.variant;
 			}
 
-			if (!Array.isArray(conditions)) continue;
+			if (!isObject(conditions)) continue;
 
-			const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
-			if (result === true) {
-				return rule.variant;
+			try {
+				const result = this._jsonExpr.evaluateBooleanExpr(conditions, vars);
+				if (result === true) {
+					return rule.variant;
+				}
+			} catch (e) {
+				console.warn(`Failed to evaluate assignment rule conditions for variant ${rule.variant}: ${e}`);
 			}
 		}
 

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -35,12 +35,12 @@ export class AudienceMatcher {
 						}
 						const conditions = rule.and;
 						if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
-							return rule.variant;
+							return typeof rule.variant === "number" ? rule.variant : null;
 						}
 						if (Array.isArray(conditions)) {
 							const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
 							if (result === true) {
-								return rule.variant;
+								return typeof rule.variant === "number" ? rule.variant : null;
 							}
 						}
 					}

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -17,5 +17,40 @@ export class AudienceMatcher {
 		return null;
 	}
 
+	evaluateRules(
+		audienceString: string,
+		environmentName: string | null,
+		vars: Record<string, unknown>
+	): number | null {
+		try {
+			const audience = JSON.parse(audienceString);
+			if (audience && Array.isArray(audience.rules)) {
+				for (const ruleGroup of audience.rules) {
+					if (!ruleGroup || !Array.isArray(ruleGroup.or)) continue;
+					for (const rule of ruleGroup.or) {
+						if (Array.isArray(rule.environments) && rule.environments.length > 0) {
+							if (environmentName == null || !rule.environments.includes(environmentName)) {
+								continue;
+							}
+						}
+						const conditions = rule.and;
+						if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
+							return rule.variant;
+						}
+						if (Array.isArray(conditions)) {
+							const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
+							if (result === true) {
+								return rule.variant;
+							}
+						}
+					}
+				}
+			}
+		} catch (error) {
+			// parse error or evaluation error - fall through to normal assignment
+		}
+		return null;
+	}
+
 	_jsonExpr = new JsonExpr();
 }

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -28,29 +28,28 @@ export class AudienceMatcher {
 
 		if (!assignmentRules || !Array.isArray(assignmentRules.rules)) return null;
 
-		for (const ruleGroup of assignmentRules.rules) {
-			if (!ruleGroup || !Array.isArray(ruleGroup.or)) continue;
-			for (const rule of ruleGroup.or) {
-				if (Array.isArray(rule.environments) && rule.environments.length > 0) {
-					if (environmentId == null || !rule.environments.includes(environmentId)) {
-						continue;
-					}
+		for (const rule of assignmentRules.rules) {
+			if (!rule) continue;
+
+			if (Array.isArray(rule.environments) && rule.environments.length > 0) {
+				if (environmentId == null || !rule.environments.includes(environmentId)) {
+					continue;
 				}
+			}
 
-				if (typeof rule.variant !== "number") continue;
+			if (typeof rule.variant !== "number") continue;
 
-				const conditions = rule.and;
+			const conditions = rule.and;
 
-				if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
-					return rule.variant;
-				}
+			if (!conditions || (Array.isArray(conditions) && conditions.length === 0)) {
+				return rule.variant;
+			}
 
-				if (!Array.isArray(conditions)) continue;
+			if (!Array.isArray(conditions)) continue;
 
-				const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
-				if (result === true) {
-					return rule.variant;
-				}
+			const result = this._jsonExpr.evaluateBooleanExpr({ and: conditions }, vars);
+			if (result === true) {
+				return rule.variant;
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Add `evaluateRules()` to `AudienceMatcher` supporting the new `rules[].or[]` payload structure with environment scoping and JsonExpr conditions
- Integrate rules evaluation into `Context._assign()` — rules are checked after audience filter but before `audienceStrict` / traffic split
- Add `getEnvironment()` to `Client` so the Context can access the environment name for rule filtering
- Add `targetingRule` flag to exposure events for explicit identification in analytics
- Validate `rule.variant` is a number; skip invalid rules instead of aborting iteration

## Assignment Flags

Rule-matched assignments set `assigned=true, eligible=true, overridden=true, targetingRule=true`.

### All possible assignment states

| State | `assigned` | `eligible` | `overridden` | `fullOn` | `custom` | `audienceMismatch` | `targetingRule` |
|---|---|---|---|---|---|---|---|
| **Not running** | false | true | false | false | false | false | false |
| **Override** | false | true | true | false | false | false | false |
| **Audience strict mismatch** | false | true | false | false | false | true | false |
| **Rule match** | true | true | true | false | false | * | true |
| **Normal (eligible)** | true | true | false | false | false | false | false |
| **Normal (not eligible)** | true | false | false | false | false | false | false |
| **Custom assignment** | true | true | false | false | true | false | false |
| **Full-on** | true | true | false | true | false | false | false |

`*` = `audienceMismatch` is set independently before rules, can be either value.

### Engine bitmask

`targetingRule` uses bit 8 (value 256). The existing filter `bitAnd(flags, 207) = 3` has bit 8 as `0` in the mask, so it's automatically ignored — no engine query changes needed. The engine's `Exposure.java` and `EventForwardingManager.java` will need the new field when implementing server-side support.

## Test Plan
- [x] 21 unit tests for `evaluateRules` in matcher
- [x] 16 integration tests in context (flags, cache invalidation, overrides, variables)
- [x] All 299 tests pass (29 suites)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment-scoped assignment rules can force variant selection; exposures and published payloads now include a ruleOverride flag and variables honour rule-selected variants.

* **Behaviour**
  * Rules use first-match semantics and environment gating; malformed/invalid or out-of-range rule results fall back to normal assignment; explicit overrides take precedence; caching and assignment recompute when attributes or rule context change.

* **Tests**
  * Expanded coverage for rule evaluation, environment gating, precedence, cache invalidation and many edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->