### PR TITLE
feat: always add API key to endpoint requests

### DIFF
--- a/src/__tests__/client.test.js
+++ b/src/__tests__/client.test.js
@@ -197,6 +197,14 @@ describe("Client", () => {
 			expect(fetch).toHaveBeenCalledTimes(1);
 			expect(fetch).toHaveBeenCalledWith(`${endpoint}/context?application=test_app&environment=test`, {
 				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+					"X-API-Key": apiKey,
+					"X-Agent": "javascript-client",
+					"X-Environment": "test",
+					"X-Application": "test_app",
+					"X-Application-Version": 1000000,
+				},
 				keepalive: true,
 				signal: expect.any(Object),
 			});
@@ -217,7 +225,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -266,7 +273,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -310,7 +316,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -361,7 +366,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -402,7 +406,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -428,7 +431,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -455,7 +457,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -497,7 +498,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -532,7 +532,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -562,7 +561,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1 },
@@ -587,7 +585,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "POST",
 				path: "/context",
 				query: { a: 1 },
@@ -625,7 +622,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "POST",
 				path: "/context",
 				query: { a: 1 },
@@ -663,7 +659,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: { a: 1, b: "ã=á" },
@@ -699,7 +694,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 				query: {},
@@ -735,7 +729,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 			})
@@ -769,7 +762,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 			})
@@ -787,32 +779,6 @@ describe("Client", () => {
 					},
 					keepalive: true,
 					body: undefined,
-					signal: expect.any(Object),
-				});
-
-				expect(response).toEqual(defaultMockResponse);
-
-				done();
-			});
-	});
-
-	it("request() should not send headers when auth argument is false", (done) => {
-		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
-
-		const client = new Client(Object.assign({}, clientOptions, { application: "website" }));
-
-		client
-			.request({
-				auth: false,
-				method: "PUT",
-				path: "/context",
-			})
-			.then((response) => {
-				expect(fetch).toHaveBeenCalledTimes(1);
-				expect(fetch).toHaveBeenLastCalledWith(`${endpoint}/context`, {
-					method: "PUT",
-					body: undefined,
-					keepalive: true,
 					signal: expect.any(Object),
 				});
 
@@ -954,7 +920,6 @@ describe("Client", () => {
 
 		client
 			.request({
-				auth: true,
 				method: "PUT",
 				path: "/context",
 			})

--- a/src/__tests__/client.test.js
+++ b/src/__tests__/client.test.js
@@ -814,6 +814,75 @@ describe("Client", () => {
 			});
 	});
 
+	it("request() should still send headers when auth is explicitly true (deprecated)", (done) => {
+		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
+
+		const client = new Client(clientOptions);
+
+		client
+			.request({
+				auth: true,
+				method: "PUT",
+				path: "/context",
+			})
+			.then((response) => {
+				expect(fetch).toHaveBeenCalledTimes(1);
+				expect(fetch).toHaveBeenLastCalledWith(`${endpoint}/context`, {
+					method: "PUT",
+					headers: {
+						"Content-Type": "application/json",
+						"X-API-Key": apiKey,
+						"X-Agent": "javascript-client",
+						"X-Environment": "test",
+						"X-Application": "test_app",
+						"X-Application-Version": 1000000,
+					},
+					body: undefined,
+					keepalive: true,
+					signal: expect.any(Object),
+				});
+
+				expect(response).toEqual(defaultMockResponse);
+
+				done();
+			});
+	});
+
+	it("get() should send a GET request with headers", (done) => {
+		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
+
+		const client = new Client(clientOptions);
+
+		client
+			.get({
+				path: "/context",
+				query: { application: "test_app", environment: "test" },
+			})
+			.then((response) => {
+				expect(fetch).toHaveBeenCalledTimes(1);
+				expect(fetch).toHaveBeenLastCalledWith(
+					`${endpoint}/context?application=test_app&environment=test`,
+					{
+						method: "GET",
+						headers: {
+							"Content-Type": "application/json",
+							"X-API-Key": apiKey,
+							"X-Agent": "javascript-client",
+							"X-Environment": "test",
+							"X-Application": "test_app",
+							"X-Application-Version": 1000000,
+						},
+						keepalive: true,
+						signal: expect.any(Object),
+					}
+				);
+
+				expect(response).toEqual(defaultMockResponse);
+
+				done();
+			});
+	});
+
 	it("publish() calls endpoint", (done) => {
 		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
 

--- a/src/__tests__/client.test.js
+++ b/src/__tests__/client.test.js
@@ -816,6 +816,7 @@ describe("Client", () => {
 
 	it("request() should still send headers when auth is explicitly true (deprecated)", (done) => {
 		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
+		const warnSpy = jest.spyOn(console, "warn").mockImplementation();
 
 		const client = new Client(clientOptions);
 
@@ -842,8 +843,13 @@ describe("Client", () => {
 					signal: expect.any(Object),
 				});
 
+				expect(warnSpy).toHaveBeenCalledWith(
+					"[ABsmartly] The `auth` option is deprecated. Auth headers are now sent by default. Remove `auth: true` from your request options."
+				);
+
 				expect(response).toEqual(defaultMockResponse);
 
+				warnSpy.mockRestore();
 				done();
 			});
 	});
@@ -855,6 +861,69 @@ describe("Client", () => {
 
 		client
 			.get({
+				path: "/context",
+				query: { application: "test_app", environment: "test" },
+			})
+			.then((response) => {
+				expect(fetch).toHaveBeenCalledTimes(1);
+				expect(fetch).toHaveBeenLastCalledWith(
+					`${endpoint}/context?application=test_app&environment=test`,
+					{
+						method: "GET",
+						headers: {
+							"Content-Type": "application/json",
+							"X-API-Key": apiKey,
+							"X-Agent": "javascript-client",
+							"X-Environment": "test",
+							"X-Application": "test_app",
+							"X-Application-Version": 1000000,
+						},
+						keepalive: true,
+						signal: expect.any(Object),
+					}
+				);
+
+				expect(response).toEqual(defaultMockResponse);
+
+				done();
+			});
+	});
+
+	it("get() should not send headers when auth is false", (done) => {
+		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
+
+		const client = new Client(Object.assign({}, clientOptions, { application: "website" }));
+
+		client
+			.get({
+				auth: false,
+				path: "/context",
+				query: { application: "website", environment: "test" },
+			})
+			.then((response) => {
+				expect(fetch).toHaveBeenCalledTimes(1);
+				expect(fetch).toHaveBeenLastCalledWith(
+					`${endpoint}/context?application=website&environment=test`,
+					{
+						method: "GET",
+						keepalive: true,
+						signal: expect.any(Object),
+					}
+				);
+
+				expect(response).toEqual(defaultMockResponse);
+
+				done();
+			});
+	});
+
+	it("getUnauthed() should forward to get()", (done) => {
+		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
+
+		const client = new Client(clientOptions);
+
+		client
+			.getUnauthed({
 				path: "/context",
 				query: { application: "test_app", environment: "test" },
 			})

--- a/src/__tests__/client.test.js
+++ b/src/__tests__/client.test.js
@@ -788,6 +788,32 @@ describe("Client", () => {
 			});
 	});
 
+	it("request() should not send headers when auth argument is false", (done) => {
+		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
+
+		const client = new Client(Object.assign({}, clientOptions, { application: "website" }));
+
+		client
+			.request({
+				auth: false,
+				method: "PUT",
+				path: "/context",
+			})
+			.then((response) => {
+				expect(fetch).toHaveBeenCalledTimes(1);
+				expect(fetch).toHaveBeenLastCalledWith(`${endpoint}/context`, {
+					method: "PUT",
+					body: undefined,
+					keepalive: true,
+					signal: expect.any(Object),
+				});
+
+				expect(response).toEqual(defaultMockResponse);
+
+				done();
+			});
+	});
+
 	it("publish() calls endpoint", (done) => {
 		fetch.mockResolvedValueOnce(responseMock(200, "OK", defaultMockResponse));
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,7 +21,7 @@ export type ClientRequestOptions = {
 	path: string;
 	method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 	body?: Record<string, unknown>;
-	/** @deprecated The API key is now always sent. This option will be removed in a future version. */
+	/** @deprecated The API key is sent by default; set to false to suppress auth headers. */
 	auth?: boolean;
 	signal?: AbortSignal | ABsmartlyAbortSignal;
 	timeout?: number;

--- a/src/client.ts
+++ b/src/client.ts
@@ -162,6 +162,12 @@ export default class Client {
 				keepalive: this._opts.keepalive,
 			};
 
+			if (options.auth === true) {
+				console.warn(
+					"[ABsmartly] The `auth` option is deprecated. Auth headers are now sent by default. Remove `auth: true` from your request options."
+				);
+			}
+
 			if (options.auth !== false) {
 				opts.headers = {
 					"Content-Type": "application/json",
@@ -306,5 +312,10 @@ export default class Client {
 			...options,
 			method: "GET",
 		});
+	}
+
+	/** @deprecated Use get() instead. */
+	getUnauthed(options: ClientRequestOptions) {
+		return this.get(options);
 	}
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,8 @@ export type ClientRequestOptions = {
 	path: string;
 	method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 	body?: Record<string, unknown>;
+	/** @deprecated The API key is now always sent. This option will be removed in a future version. */
+	auth?: boolean;
 	signal?: AbortSignal | ABsmartlyAbortSignal;
 	timeout?: number;
 };
@@ -160,14 +162,16 @@ export default class Client {
 				keepalive: this._opts.keepalive,
 			};
 
-			opts.headers = {
-				"Content-Type": "application/json",
-				"X-API-Key": this._opts.apiKey,
-				"X-Agent": this._opts.agent,
-				"X-Environment": this._opts.environment,
-				"X-Application": this._opts.application.name,
-				"X-Application-Version": this._opts.application.version,
-			};
+			if (options.auth !== false) {
+				opts.headers = {
+					"Content-Type": "application/json",
+					"X-API-Key": this._opts.apiKey,
+					"X-Agent": this._opts.agent,
+					"X-Environment": this._opts.environment,
+					"X-Application": this._opts.application.name,
+					"X-Application-Version": this._opts.application.version,
+				};
+			}
 
 			return fetch(url, opts).then((response: FetchResponse) => {
 				if (!response.ok) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,7 +21,6 @@ export type ClientRequestOptions = {
 	path: string;
 	method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 	body?: Record<string, unknown>;
-	auth?: boolean;
 	signal?: AbortSignal | ABsmartlyAbortSignal;
 	timeout?: number;
 };
@@ -90,7 +89,7 @@ export default class Client {
 	}
 
 	getContext(options?: Partial<ClientRequestOptions>) {
-		return this.getUnauthed({
+		return this.get({
 			...options,
 			path: "/context",
 			query: {
@@ -161,16 +160,14 @@ export default class Client {
 				keepalive: this._opts.keepalive,
 			};
 
-			if (options.auth) {
-				opts.headers = {
-					"Content-Type": "application/json",
-					"X-API-Key": this._opts.apiKey,
-					"X-Agent": this._opts.agent,
-					"X-Environment": this._opts.environment,
-					"X-Application": this._opts.application.name,
-					"X-Application-Version": this._opts.application.version,
-				};
-			}
+			opts.headers = {
+				"Content-Type": "application/json",
+				"X-API-Key": this._opts.apiKey,
+				"X-Agent": this._opts.agent,
+				"X-Environment": this._opts.environment,
+				"X-Application": this._opts.application.name,
+				"X-Application-Version": this._opts.application.version,
+			};
 
 			return fetch(url, opts).then((response: FetchResponse) => {
 				if (!response.ok) {
@@ -281,7 +278,6 @@ export default class Client {
 	post(options: ClientRequestOptions) {
 		return this.request({
 			...options,
-			auth: true,
 			method: "POST",
 		});
 	}
@@ -289,7 +285,6 @@ export default class Client {
 	put(options: ClientRequestOptions) {
 		return this.request({
 			...options,
-			auth: true,
 			method: "PUT",
 		});
 	}
@@ -302,7 +297,7 @@ export default class Client {
 		return this._opts.application;
 	}
 
-	getUnauthed(options: ClientRequestOptions) {
+	get(options: ClientRequestOptions) {
 		return this.request({
 			...options,
 			method: "GET",


### PR DESCRIPTION
This PR deprecates the `auth` flag in the `ClientRequestOptions` type, and updates the context `GET` request to always send the auth headers with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Requests now send API and client metadata headers by default; the legacy auth flag is deprecated and only disables those headers. GET helper was streamlined and a deprecated wrapper retained for compatibility.

* **Tests**
  * Tests expanded to verify metadata headers for GET and other requests, cover auth flag deprecation behaviour and related warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->