### PR TITLE
chore: bump version to 1.14.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.13.2",
+	"version": "1.14.0-beta.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@absmartly/javascript-sdk",
-			"version": "1.13.2",
+			"version": "1.14.0-beta.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"core-js": "^3.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@absmartly/javascript-sdk",
-	"version": "1.13.4",
+	"version": "1.14.0-beta.0",
 	"description": "A/B Smartly Javascript SDK",
 	"homepage": "https://github.com/absmartly/javascript-sdk#README.md",
 	"bugs": "https://github.com/absmartly/javascript-sdk/issues",

--- a/src/__tests__/client.test.js
+++ b/src/__tests__/client.test.js
@@ -866,22 +866,19 @@ describe("Client", () => {
 			})
 			.then((response) => {
 				expect(fetch).toHaveBeenCalledTimes(1);
-				expect(fetch).toHaveBeenLastCalledWith(
-					`${endpoint}/context?application=test_app&environment=test`,
-					{
-						method: "GET",
-						headers: {
-							"Content-Type": "application/json",
-							"X-API-Key": apiKey,
-							"X-Agent": "javascript-client",
-							"X-Environment": "test",
-							"X-Application": "test_app",
-							"X-Application-Version": 1000000,
-						},
-						keepalive: true,
-						signal: expect.any(Object),
-					}
-				);
+				expect(fetch).toHaveBeenLastCalledWith(`${endpoint}/context?application=test_app&environment=test`, {
+					method: "GET",
+					headers: {
+						"Content-Type": "application/json",
+						"X-API-Key": apiKey,
+						"X-Agent": "javascript-client",
+						"X-Environment": "test",
+						"X-Application": "test_app",
+						"X-Application-Version": 1000000,
+					},
+					keepalive: true,
+					signal: expect.any(Object),
+				});
 
 				expect(response).toEqual(defaultMockResponse);
 
@@ -902,14 +899,11 @@ describe("Client", () => {
 			})
 			.then((response) => {
 				expect(fetch).toHaveBeenCalledTimes(1);
-				expect(fetch).toHaveBeenLastCalledWith(
-					`${endpoint}/context?application=website&environment=test`,
-					{
-						method: "GET",
-						keepalive: true,
-						signal: expect.any(Object),
-					}
-				);
+				expect(fetch).toHaveBeenLastCalledWith(`${endpoint}/context?application=website&environment=test`, {
+					method: "GET",
+					keepalive: true,
+					signal: expect.any(Object),
+				});
 
 				expect(response).toEqual(defaultMockResponse);
 
@@ -929,22 +923,19 @@ describe("Client", () => {
 			})
 			.then((response) => {
 				expect(fetch).toHaveBeenCalledTimes(1);
-				expect(fetch).toHaveBeenLastCalledWith(
-					`${endpoint}/context?application=test_app&environment=test`,
-					{
-						method: "GET",
-						headers: {
-							"Content-Type": "application/json",
-							"X-API-Key": apiKey,
-							"X-Agent": "javascript-client",
-							"X-Environment": "test",
-							"X-Application": "test_app",
-							"X-Application-Version": 1000000,
-						},
-						keepalive: true,
-						signal: expect.any(Object),
-					}
-				);
+				expect(fetch).toHaveBeenLastCalledWith(`${endpoint}/context?application=test_app&environment=test`, {
+					method: "GET",
+					headers: {
+						"Content-Type": "application/json",
+						"X-API-Key": apiKey,
+						"X-Agent": "javascript-client",
+						"X-Environment": "test",
+						"X-Application": "test_app",
+						"X-Application-Version": 1000000,
+					},
+					keepalive: true,
+					signal: expect.any(Object),
+				});
 
 				expect(response).toEqual(defaultMockResponse);
 

--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -2400,10 +2400,12 @@ describe("Context", () => {
 						{
 							name: "US Internal",
 							type: "assign",
-							conditions: { and: [
-								{ eq: [{ var: "country" }, { value: "US" }] },
-								{ eq: [{ var: "user_type" }, { value: "internal" }] },
-							] },
+							conditions: {
+								and: [
+									{ eq: [{ var: "country" }, { value: "US" }] },
+									{ eq: [{ var: "user_type" }, { value: "internal" }] },
+								],
+							},
 							environments: [],
 							variant: 1,
 						},

--- a/src/context.ts
+++ b/src/context.ts
@@ -439,11 +439,13 @@ export default class Context {
 		}
 	}
 
-	private _computeRuleVariant(assignmentRules: string, variantCount: number, attrs: Record<string, unknown>): number | null {
+	private _computeRuleVariant(
+		assignmentRules: string,
+		variantCount: number,
+		attrs: Record<string, unknown>
+	): number | null {
 		const rawRuleVariant = this._audienceMatcher.evaluateRules(assignmentRules, this._environmentName, attrs);
-		return rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < variantCount
-			? rawRuleVariant
-			: null;
+		return rawRuleVariant !== null && rawRuleVariant >= 0 && rawRuleVariant < variantCount ? rawRuleVariant : null;
 	}
 
 	private _checkReady(expectNotFinalized?: boolean) {
@@ -463,7 +465,10 @@ export default class Context {
 			const app = client.getApplication();
 			attrs["application"] = app.name;
 			attrs["environment"] = client.getEnvironment() ?? null;
-			if ((typeof app.version === "string" && app.version.length > 0) || (typeof app.version === "number" && app.version > 0)) {
+			if (
+				(typeof app.version === "string" && app.version.length > 0) ||
+				(typeof app.version === "number" && app.version > 0)
+			) {
 				attrs["app_version"] = app.version;
 			}
 		}
@@ -485,9 +490,7 @@ export default class Context {
 		};
 
 		const audienceMatches = (experiment: ExperimentData, assignment: Assignment) => {
-			const ruleKey = experiment.assignmentRules
-				? `${experiment.assignmentRules}:${this._environmentName}`
-				: "";
+			const ruleKey = experiment.assignmentRules ? `${experiment.assignmentRules}:${this._environmentName}` : "";
 			const ruleKeyChanged = ruleKey !== (assignment.ruleKey ?? "");
 
 			if (ruleKeyChanged) {
@@ -584,7 +587,11 @@ export default class Context {
 				const attrs = this._getAttributesMap();
 
 				if (experiment.data.assignmentRules && experiment.data.assignmentRules.length > 0) {
-					ruleVariant = this._computeRuleVariant(experiment.data.assignmentRules, experiment.data.variants.length, attrs);
+					ruleVariant = this._computeRuleVariant(
+						experiment.data.assignmentRules,
+						experiment.data.variants.length,
+						attrs
+					);
 				}
 
 				assignment.ruleVariant = ruleVariant;
@@ -868,7 +875,10 @@ export default class Context {
 				{ name: "application", value: app.name, setAt: now },
 				{ name: "environment", value: client.getEnvironment() ?? null, setAt: now }
 			);
-			if ((typeof app.version === "string" && app.version.length > 0) || (typeof app.version === "number" && app.version > 0)) {
+			if (
+				(typeof app.version === "string" && app.version.length > 0) ||
+				(typeof app.version === "number" && app.version > 0)
+			) {
 				allAttributes.push({ name: "app_version", value: app.version, setAt: now });
 			}
 		}

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -17,7 +17,11 @@ export class AudienceMatcher {
 		return null;
 	}
 
-	evaluateRules(assignmentRulesString: string, environmentName: string | null, vars: Record<string, unknown>): number | null {
+	evaluateRules(
+		assignmentRulesString: string,
+		environmentName: string | null,
+		vars: Record<string, unknown>
+	): number | null {
 		let assignmentRules;
 		try {
 			assignmentRules = JSON.parse(assignmentRulesString);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "1.13.4";
+export const SDK_VERSION = "1.14.0-beta.0";


### PR DESCRIPTION
## Summary
- Bumps version from 1.13.4 to 1.14.0-beta.0 in `package.json`, `package-lock.json`, and `src/version.ts`

## Test plan
- [ ] Verify `npm run generate-version` produces the correct `src/version.ts`
- [ ] Verify `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package and SDK version bumped to 1.14.0‑beta.0

* **Style**
  * Code formatting adjustments across several modules (no behavioural changes)

* **Tests**
  * Test assertions and fixtures reformatted for readability (no logic changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->