### PR TITLE
FT-1860: Fix refreshInterval -> refreshPeriod in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ await context.finalize().then(() => {
 #### Refreshing the context with fresh experiment data
 For long-running single-page-applications (SPA), the context is usually created once when the application is first reached.
 However, any experiments being tracked in your production code, but started after the context was created, will not be triggered.
-To mitigate this, we can use the `refreshInterval` option when creating the context.
+To mitigate this, we can use the `refreshPeriod` option when creating the context.
 
 ```javascript
 const request = {
@@ -215,7 +215,7 @@ const request = {
 };
 
 const context = sdk.createContext(request, {
-    refreshInterval: 5 * 60 * 1000
+    refreshPeriod: 5 * 60 * 1000
 });
 ```
 
@@ -293,7 +293,7 @@ Here is an example of setting a timeout only for the createContext request.
 
 ```javascript
 const context = sdk.createContext(request, {
-    refreshInterval: 5 * 60 * 1000
+    refreshPeriod: 5 * 60 * 1000
 }, {
     timeout: 1500
 });
@@ -307,7 +307,7 @@ Here is an example of a cancellation scenario.
 ```javascript
 const controller = new absmartly.AbortController();
 const context = sdk.createContext(request, {
-    refreshInterval: 5 * 60 * 1000
+    refreshPeriod: 5 * 60 * 1000
 }, {
     signal: controller.signal
 });


### PR DESCRIPTION
## Description

The README references `refreshInterval` in code examples and text, but the actual `ContextOptions` type uses `refreshPeriod`. This causes confusion for SDK users who copy-paste the examples.

Jira Issue [FT-1860](https://absmartly.atlassian.net/browse/FT-1860)

## Solution

Replaced all 4 occurrences of `refreshInterval` with `refreshPeriod` in README.md to match the actual type definition at `src/context.ts:122`.

## Before & After

**BEFORE:**
```javascript
const context = sdk.createContext(request, {
    refreshInterval: 5 * 60 * 1000
});
```

**AFTER:**
```javascript
const context = sdk.createContext(request, {
    refreshPeriod: 5 * 60 * 1000
});
```

## Other Changes

None.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] New and existing unit tests pass locally with my changes

[FT-1860]: https://absmartly.atlassian.net/browse/FT-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples to reflect the correct option name (`refreshPeriod`) for auto-refresh settings and other context creation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->