### PR TITLE
ci: auto-publish to npm on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Read version from package.json
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          V=$(node -p "require('./package.json').version")
+          if [ -z "$V" ] || [ "$V" = "undefined" ]; then
+            echo "package.json has no version field" >&2
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version is already on npm
+        id: check
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          ALL_VERSIONS=$(npm view "@absmartly/javascript-sdk" versions --json)
+          if echo "$ALL_VERSIONS" | jq -e --arg v "$VERSION" 'index($v) != null' >/dev/null; then
+            echo "Version ${VERSION} already published - skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version ${VERSION} is not on npm - will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Derive npm dist-tag
+        if: steps.check.outputs.should_publish == 'true'
+        id: tag
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Substring-based by design - see docs/superpowers/specs/2026-04-24-auto-publish-design.md
+          case "$VERSION" in
+            *-alpha*) TAG=alpha ;;
+            *-beta*)  TAG=beta ;;
+            *)        TAG=latest ;;
+          esac
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm
+        if: steps.check.outputs.should_publish == 'true'
+        env:
+          NPM_TAG: ${{ steps.tag.outputs.tag }}
+        run: npm publish --provenance --tag "$NPM_TAG"

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,8 @@ node_modules
 coverage
 dist
 es
+js
 lib
+types
 package-lock.json
+.claude

--- a/docs/superpowers/plans/2026-04-24-auto-publish.md
+++ b/docs/superpowers/plans/2026-04-24-auto-publish.md
@@ -1,0 +1,288 @@
+# Auto-publish Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions workflow that auto-publishes `@absmartly/javascript-sdk` to npm whenever a merge to `main` introduces a new `version` in `package.json`.
+
+**Architecture:** A single new workflow file `.github/workflows/publish.yml` triggered on push to `main`. Reads `version` from `package.json`, queries npm to see if it's already published, derives the dist-tag from the version string (`alpha` / `beta` / `latest`), and publishes with provenance via OIDC trusted publishing. No token secret in the repo.
+
+**Tech Stack:** GitHub Actions, Node.js 24 (from `.nvmrc`), npm (OIDC trusted publishing + provenance).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-24-auto-publish-design.md`
+
+---
+
+## Testing philosophy
+
+GitHub Actions workflows can't be unit-tested in the TDD sense — there's no local harness that exercises OIDC, merge events, and the npm registry end-to-end. Verification is therefore:
+
+1. **Static:** YAML parses and passes actionlint.
+2. **Dry-run on main:** first merge lands a commit where the version is already published → workflow runs, version-check step exits green without publishing.
+3. **Wet-run on main:** follow-up PR bumps version → workflow publishes; confirm via `npm view`.
+
+Each task below is explicit about which level of verification applies.
+
+---
+
+## Prerequisite (manual, human-only)
+
+One-time setup on npmjs.com. The workflow will fail at the publish step until this is done.
+
+- [ ] **P1:** Visit <https://www.npmjs.com/package/@absmartly/javascript-sdk/access>
+- [ ] **P2:** Settings → Trusted Publishing → GitHub Actions. Add a new trusted publisher with:
+  - **Organization or user:** `absmartly`
+  - **Repository:** `javascript-sdk`
+  - **Workflow filename:** `publish.yml`
+  - **Environment name:** (leave empty)
+- [ ] **P3:** Save.
+
+---
+
+## Task 1: Create working branch
+
+**Files:** none (git branch operation)
+
+- [ ] **Step 1.1: Confirm clean working tree**
+
+Run: `git status`
+Expected: `nothing to commit, working tree clean` (or only untracked files unrelated to this task — flag any surprise changes before continuing).
+
+- [ ] **Step 1.2: Create branch**
+
+Run:
+```bash
+git checkout -b ci/auto-publish
+```
+
+---
+
+## Task 2: Write the publish workflow
+
+**Files:**
+- Create: `.github/workflows/publish.yml`
+
+- [ ] **Step 2.1: Create the workflow file**
+
+Write `.github/workflows/publish.yml` with exactly this content:
+
+```yaml
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Read version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version is already on npm
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          V="${{ steps.version.outputs.version }}"
+          PUBLISHED=$(npm view "@absmartly/javascript-sdk@${V}" version)
+          if [ -z "$PUBLISHED" ]; then
+            echo "Version ${V} is not on npm — will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version ${V} already published — skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Derive npm dist-tag
+        if: steps.check.outputs.should_publish == 'true'
+        id: tag
+        shell: bash
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          case "$V" in
+            *-alpha*) TAG=alpha ;;
+            *-beta*)  TAG=beta ;;
+            *)        TAG=latest ;;
+          esac
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to npm
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish --provenance --tag "${{ steps.tag.outputs.tag }}"
+```
+
+Notes on the content (do not add as comments in the YAML — they're for the implementer):
+- `registry-url` on `setup-node` is required for `npm publish` to authenticate via OIDC.
+- `npm ci --ignore-scripts` matches the pattern in `build.yml`.
+- No `--access public` needed; `publishConfig.access: public` is already in `package.json`.
+- Running `npm publish` triggers `prepack`, which runs the full `npm run build` (format/lint/compile/test/build-*). That's intentional — tests gate the publish.
+- `set -euo pipefail` makes the version-check step fail on any unexpected `npm view` error (matches spec's third case).
+
+- [ ] **Step 2.2: Verify YAML parses**
+
+Run:
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/publish.yml'))" && echo OK
+```
+Expected: `OK`.
+
+- [ ] **Step 2.3: Lint with actionlint (if available)**
+
+Run:
+```bash
+command -v actionlint >/dev/null && actionlint .github/workflows/publish.yml || echo "actionlint not installed — skipping (will be caught on push)"
+```
+Expected: either no output (lint clean) or the "skipping" message.
+
+Do not install actionlint just for this check — GitHub will surface any real syntax errors when the workflow lands on `main`.
+
+---
+
+## Task 3: Commit and push
+
+**Files:** none (git only)
+
+- [ ] **Step 3.1: Stage and commit**
+
+Run:
+```bash
+git add .github/workflows/publish.yml
+git commit -m "ci: auto-publish to npm on merge to main
+
+Adds .github/workflows/publish.yml. Fires on push to main, skips
+silently if the package.json version is already on npm, otherwise
+derives the dist-tag from the version string (alpha/beta/latest)
+and publishes with provenance via OIDC trusted publishing. Requires
+a one-time Trusted Publisher configuration on npmjs.com for this
+package (see docs/superpowers/specs/2026-04-24-auto-publish-design.md)."
+```
+
+- [ ] **Step 3.2: Push**
+
+Run:
+```bash
+git push -u origin ci/auto-publish
+```
+
+---
+
+## Task 4: Open PR
+
+**Files:** none
+
+- [ ] **Step 4.1: Open PR**
+
+Run:
+```bash
+gh pr create --title "ci: auto-publish to npm on merge to main" --body "$(cat <<'EOF'
+## Summary
+- Adds \`.github/workflows/publish.yml\` — publishes to npm on push to main when \`package.json\` version changes.
+- OIDC trusted publishing (no \`NPM_TOKEN\` secret needed); provenance attestations enabled.
+- Tag derived from version: \`-alpha\` → \`alpha\`, \`-beta\` → \`beta\`, else \`latest\`.
+- Design: \`docs/superpowers/specs/2026-04-24-auto-publish-design.md\`.
+
+## Prerequisite
+Complete the Trusted Publisher setup on https://www.npmjs.com/package/@absmartly/javascript-sdk/access **before merging**. Until it's done, the publish step of this workflow will fail.
+
+## Test plan
+- [ ] YAML parses and actionlint passes (local).
+- [ ] After merge, first workflow run on main (where \`package.json\` version is already on npm) exits green without publishing.
+- [ ] Open a follow-up PR bumping version to \`1.14.0-beta.2\`; after merge, workflow publishes and \`npm view @absmartly/javascript-sdk dist-tags\` shows \`beta: 1.14.0-beta.2\` with a provenance badge on npmjs.com.
+EOF
+)"
+```
+
+- [ ] **Step 4.2: Confirm required checks pass on the PR**
+
+Watch the PR's Actions runs. `build.yml` should run (format + build + test). The new `publish.yml` only runs on push to `main`, so it will not run on the PR itself.
+
+---
+
+## Task 5: Post-merge — dry-run verification
+
+**When to do this:** after the PR from Task 4 is merged, but before any version bump.
+
+- [ ] **Step 5.1: Open the Actions tab**
+
+Navigate to the repo's Actions tab on GitHub. Find the `Publish` workflow run triggered by the merge commit.
+
+- [ ] **Step 5.2: Confirm expected behavior**
+
+Expected:
+- Overall status: **success** (green).
+- `Read version from package.json` → outputs the current `package.json` version (e.g. `1.14.0-beta.1`).
+- `Check if version is already on npm` → prints `Version … already published — skipping.` and sets `should_publish=false`.
+- `Derive npm dist-tag` and `Publish to npm` steps show as **skipped**.
+- Nothing publishes. `npm view @absmartly/javascript-sdk dist-tags` output is unchanged from before.
+
+If the run fails: do NOT bump the version until you've fixed the workflow. Most likely failure modes and fixes:
+- **`npm view` step fails non-zero:** transient registry flake, re-run the job. If repeatable, check the package name spelling.
+- **Publish step fails with auth error on the dry-run:** shouldn't be reached (it's `if: should_publish == 'true'`), but if it does, the version-check logic has a bug — revisit the `[ -z "$PUBLISHED" ]` branch.
+
+---
+
+## Task 6: Post-merge — live publish verification
+
+**When to do this:** after Task 5 shows a clean dry-run.
+
+- [ ] **Step 6.1: Bump version in a small PR**
+
+Run:
+```bash
+git checkout main && git pull --ff-only
+git checkout -b chore/bump-to-beta-2
+node -e "const p=require('./package.json'); p.version='1.14.0-beta.2'; require('fs').writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');"
+git add package.json
+git commit -m "chore: bump version to 1.14.0-beta.2"
+git push -u origin chore/bump-to-beta-2
+gh pr create --title "chore: bump version to 1.14.0-beta.2" --body "Verifies the new auto-publish workflow."
+```
+
+- [ ] **Step 6.2: Merge the PR**
+
+Via `gh pr merge <number> --squash` or the GitHub UI, whichever matches the repo's convention.
+
+- [ ] **Step 6.3: Watch the Publish workflow run**
+
+Expected on the merge commit:
+- `Check if version is already on npm` → prints `Version 1.14.0-beta.2 is not on npm — will publish.`
+- `Derive npm dist-tag` → outputs `tag=beta`.
+- `Publish to npm` runs `npm publish --provenance --tag beta` and succeeds.
+
+- [ ] **Step 6.4: Confirm on the registry**
+
+Run:
+```bash
+npm view @absmartly/javascript-sdk dist-tags
+```
+Expected: `beta: '1.14.0-beta.2'`.
+
+Then open <https://www.npmjs.com/package/@absmartly/javascript-sdk/v/1.14.0-beta.2> in a browser. Confirm the "Provenance" badge is visible on the version page.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Every section in `docs/superpowers/specs/2026-04-24-auto-publish-design.md` is realised by Tasks 2 (workflow shape, version check, tag routing, OIDC auth), 5 (dry-run idempotence), and 6 (live publish + provenance). The manual npmjs.com setup is captured in the Prerequisite block.
+- **Placeholder scan:** no TBDs, TODOs, or "add appropriate X". Every code step has the actual code.
+- **Type / name consistency:** step output names (`version`, `should_publish`, `tag`) are used consistently across steps of Task 2.
+- **Non-goals respected:** plan does not generate a changelog, create a GitHub Release, or automate version bumps.

--- a/docs/superpowers/specs/2026-04-24-auto-publish-design.md
+++ b/docs/superpowers/specs/2026-04-24-auto-publish-design.md
@@ -1,0 +1,111 @@
+# Auto-publish to npm on merge to main
+
+## Summary
+
+A new GitHub Actions workflow publishes `@absmartly/javascript-sdk` to npm automatically whenever a PR merged to `main` changes the `version` in `package.json`. Authentication uses npm's OIDC trusted publishing, so no long-lived token secret lives in the repo. Published tarballs carry provenance attestations.
+
+## Motivation
+
+Today, publishing is manual: bump the version in a PR, merge, then run `npm publish` locally, which requires an npm login with 2FA. This is error-prone (forgetting to publish, publishing from a dirty working tree, hitting EOTP in the middle of a release) and couples release to one person's machine. Automating it keeps the "bump version in a PR" habit the team already uses, and removes the manual step after merge.
+
+## Goals
+
+- Publish automatically when a merge to `main` introduces a new version.
+- Route prerelease versions to the correct npm dist-tag (`alpha`, `beta`, or `latest`).
+- No npm credentials stored as repo secrets; use OIDC trusted publishing.
+- Attach npm provenance to published tarballs.
+- Idempotent: re-running on a commit whose version is already published is a silent no-op.
+
+## Non-goals
+
+- No changelog generation.
+- No GitHub Release creation.
+- No automated version bumping. Humans still bump `version` in PRs.
+- No `rc` prerelease tag handling. Add later if the project starts using it.
+- No GitHub environment / manual approval gate.
+
+## Trigger
+
+`push` to `main`. PRs are already validated by `build.yml` before merge; this workflow fires on the merge commit.
+
+## Version check
+
+Before building, the workflow reads `version` from `package.json` and queries `npm view @absmartly/javascript-sdk@<version> version`. Cases:
+
+- Exit 0, empty stdout → version not on npm → publish.
+- Exit 0, non-empty stdout → version already published → skip publish, exit green.
+- Non-zero exit → real error (network, auth, etc.) → fail the workflow. Humans investigate rather than the workflow guessing.
+
+This makes the workflow safe to re-run and safe to leave in place for commits that don't bump the version.
+
+## Tag routing
+
+Derived from the version string:
+
+| Version pattern | npm dist-tag |
+| --- | --- |
+| `*-alpha*` (e.g. `1.14.0-alpha.2`) | `alpha` |
+| `*-beta*` (e.g. `1.14.0-beta.1`) | `beta` |
+| anything else (e.g. `1.14.0`) | `latest` |
+
+Implemented as a `case` statement on the version string. Not semver-aware — just substring matching, which is sufficient for the project's current conventions.
+
+## Auth
+
+OIDC trusted publishing. The workflow job requests an OIDC token from GitHub (`id-token: write` permission), which npm exchanges for a short-lived publish credential. This also enables provenance (`npm publish --provenance`) — published tarballs get a signed attestation tying them to this repo, commit SHA, and workflow run, visible on npmjs.com.
+
+### One-time manual setup on npmjs.com
+
+Before merging this workflow, configure the package as a trusted publisher:
+
+1. Go to <https://www.npmjs.com/package/@absmartly/javascript-sdk/access>
+2. Settings → Trusted Publishing → GitHub Actions
+3. Fill in:
+   - **Organization or user:** `absmartly`
+   - **Repository:** `javascript-sdk`
+   - **Workflow filename:** `publish.yml`
+   - **Environment name:** (leave empty)
+4. Save.
+
+If step 1–4 are skipped, the first workflow run will fail at `npm publish` with an auth error; the package state on npm is unchanged.
+
+## Build
+
+Publishing runs `npm publish`, which invokes the `prepack` script (`npm run build`) — the full existing build chain (`format:check`, `lint`, `compile`, `test`, `build-es`, `build-cjs`, `build-browser`). This duplicates work `build.yml` already did on the same commit, but the duplication is cheap, keeps the workflow self-contained, and guarantees tests pass before publishing.
+
+## Workflow outline
+
+File: `.github/workflows/publish.yml`
+
+Shape (not a final draft — the implementation plan will produce the concrete YAML):
+
+- `on: push: branches: [main]`
+- One job, `publish`, running on `ubuntu-latest`
+- `permissions: contents: read, id-token: write`
+- Steps:
+  1. `actions/checkout@v6`
+  2. `actions/setup-node@v6` with `node-version-file: .nvmrc`, `registry-url: https://registry.npmjs.org`, `cache: npm`
+  3. `npm ci --ignore-scripts`
+  4. Read version from `package.json`; check `npm view` for that version; set an output like `should_publish`
+  5. If `should_publish`: derive dist-tag via `case` on version; run `npm publish --provenance --tag <derived>`
+
+`publishConfig.access: public` is already in `package.json`, so no `--access public` flag is needed.
+
+## Failure modes and recovery
+
+- **Build/test fails in `prepack`** — workflow fails; nothing published; maintainers fix and re-merge (which is itself a new commit to `main`, retriggering the workflow). Since the version on `main` has not changed, re-runs on the same commit after an infra hiccup are idempotent.
+- **OIDC exchange fails** (trusted publisher misconfigured) — workflow fails at publish step; package unchanged.
+- **Version already published** — handled by the version-check step; workflow exits green without calling `npm publish`.
+- **Race with a manual publish from a developer's laptop** — whichever publishes first wins; the other fails with "version already exists" (or, for the workflow, silently skips if the version check runs after the manual publish). Low risk now that auto-publish exists.
+
+## Testing
+
+The workflow itself can only be tested on `main`. Validate by:
+
+1. Merge this workflow (initial commit does not bump version → workflow runs, version check skips publish, job green).
+2. Open a follow-up PR bumping to `1.14.0-beta.2`; merge; confirm workflow publishes and `npm view @absmartly/javascript-sdk dist-tags` shows `beta: 1.14.0-beta.2`.
+3. Check the published version's provenance on npmjs.com.
+
+## Open questions
+
+None.

--- a/docs/superpowers/specs/2026-04-24-auto-publish-design.md
+++ b/docs/superpowers/specs/2026-04-24-auto-publish-design.md
@@ -30,11 +30,13 @@ Today, publishing is manual: bump the version in a PR, merge, then run `npm publ
 
 ## Version check
 
-Before building, the workflow reads `version` from `package.json` and queries `npm view @absmartly/javascript-sdk@<version> version`. Cases:
+Before building, the workflow reads `version` from `package.json` and queries `npm view @absmartly/javascript-sdk versions --json` to get the list of all published versions of the package. It then checks for the local version in that list:
 
-- Exit 0, empty stdout → version not on npm → publish.
-- Exit 0, non-empty stdout → version already published → skip publish, exit green.
-- Non-zero exit → real error (network, auth, etc.) → fail the workflow. Humans investigate rather than the workflow guessing.
+- Local version is in the list → version already published → skip publish, exit green.
+- Local version is not in the list → publish.
+- `npm view` exits non-zero (network error, package missing, etc.) → fail the workflow. Humans investigate rather than the workflow guessing.
+
+Querying the `versions` array (which is always populated when the package exists) avoids the trap that `npm view <pkg>@<missing-version>` exits non-zero on npm 11+, which would otherwise make any new version look like a real error to `set -euo pipefail`.
 
 This makes the workflow safe to re-run and safe to leave in place for commits that don't bump the version.
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` which auto-publishes the package to npm whenever a merge to `main` introduces a new `version` in `package.json`. Authentication is OIDC trusted publishing (no `NPM_TOKEN` secret) with provenance attestations enabled.

The PR also bundles two small dependencies of that work:
- `Ignore build outputs and worktrees in Prettier` — adds `js`, `types`, and `.claude` to `.prettierignore` so `format:check` doesn't trip on tsc output or local worktrees.
- The design spec and implementation plan under `docs/superpowers/`.

## How the workflow works

- Trigger: `push` to `main`.
- Reads `version` from `package.json` (fails the workflow if it's missing/`undefined`).
- Queries `npm view @absmartly/javascript-sdk versions --json` and checks list membership with `jq`. If the version is already on npm → green no-op. If not → publish. Genuine `npm view` failures (network, auth, etc.) fail the job.
- Tag derived from version string: `*-alpha*` → `alpha`, `*-beta*` → `beta`, else → `latest`. Substring matching, no `rc` handling (intentional, see spec).
- Publishes via `npm publish --provenance --tag <derived>`. `--access public` not passed because `publishConfig.access: public` is already in `package.json`.
- Step outputs flow into shell via `env:` vars (not `${{ }}` interpolation), which is the GitHub-recommended workflow-injection hardening.

## Required before merging

The publish step uses OIDC trusted publishing, which needs a one-time configuration on npmjs.com:

1. Visit https://www.npmjs.com/package/@absmartly/javascript-sdk/access
2. Settings → Trusted Publishing → GitHub Actions
3. Fill in: organization `absmartly`, repository `javascript-sdk`, workflow filename `publish.yml`, environment empty
4. Save

Until that's done, the publish step will fail with an OIDC auth error. The version-check / tag-derive steps run before that, so a misconfigured trusted publisher won't accidentally republish anything.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` returns `OK`).
- [ ] Trusted Publisher configured on npmjs.com per "Required before merging".
- [ ] After merge, the first workflow run on `main` (where `package.json` version is already on npm as `1.14.0-beta.1`) exits green without publishing — `Check if version is already on npm` should print "already published - skipping" and the dist-tag / publish steps should show as skipped.
- [ ] In a follow-up PR bumping to e.g. `1.14.0-beta.2`: after merge, workflow publishes; `npm view @absmartly/javascript-sdk dist-tags` shows `beta: 1.14.0-beta.2`; provenance badge visible on the version page on npmjs.com.

## Spec / plan

- Design: \`docs/superpowers/specs/2026-04-24-auto-publish-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-24-auto-publish.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured automated npm package publishing for the JavaScript SDK.
  * Updated internal configuration and documentation for publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->